### PR TITLE
chore: remove html2canvas script

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,6 @@
 
     <!-- CÓDIGO FUENTE (¡no apuntar a /assets!): -->
     <script type="module" src="/src/main.jsx"></script>
-
-    <!-- html2canvas para jsPDF.html (maquetación Bootstrap -> PDF) -->
-    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" defer></script>
     <!-- Bootstrap JS opcional -->
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
## Summary
- remove html2canvas CDN script from index.html to stop loading unused library

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm install --no-save playwright` *(fails: 403 Forbidden)*
- `npm install --no-save puppeteer` *(fails: 403 Forbidden)*
- `curl -I http://localhost:4175`


------
https://chatgpt.com/codex/tasks/task_e_68c71afe00808328936e6d939b8db451