### PR TITLE
refactor: centralize storage keys

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import plantillasBase from '../utils/plantillas.json'
 import logoImg from '../assets/logo-gep.png'
+import { triesKey, htmlKey } from '../utils/keys'
 
 const fileToDataURL = (file) =>
   new Promise((res, rej) => {
@@ -10,9 +11,6 @@ const fileToDataURL = (file) =>
     reader.onerror = rej
     reader.readAsDataURL(file)
   })
-
-const triesKey = (dealId) => `aiAttempts:${dealId || 'sin'}`
-const htmlKey  = (dealId) => `aiHtml:${dealId || 'sin'}`
 
 export default function Form({ initial, onNext }) {
   const formRef = useRef(null)

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -2,10 +2,9 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import logoImg from '../assets/logo-gep.png'
 import { generateReportPdfmake } from '../pdf/reportPdfmake'
+import { triesKey, htmlKey } from '../utils/keys'
 
 const maxTries = 3
-const triesKey = (dealId) => `aiAttempts:${dealId || 'sin'}`
-const htmlKey  = (dealId) => `aiHtml:${dealId || 'sin'}`
 
 /**
  * Editor NO controlado para el HTML de IA (sin saltos de cursor):

--- a/src/pdf/reportPdfmake.js
+++ b/src/pdf/reportPdfmake.js
@@ -11,8 +11,7 @@ import footerImg from '../assets/pdf/footer.png'
 import PoppinsRegular   from '../assets/fonts/Poppins-Regular.ttf'
 import PoppinsBold      from '../assets/fonts/Poppins-Bold.ttf'
 import PoppinsSemiBold  from '../assets/fonts/Poppins-SemiBold.ttf'
-
-const htmlKey = (dealId) => `aiHtml:${dealId || 'sin'}`
+import { htmlKey } from '../utils/keys'
 
 // ---------- utils ----------
 const toDataURL = async (url) => {

--- a/src/utils/keys.js
+++ b/src/utils/keys.js
@@ -1,0 +1,5 @@
+// src/utils/keys.js
+
+export const triesKey = (dealId) => `aiAttempts:${dealId || 'sin'}`
+export const htmlKey  = (dealId) => `aiHtml:${dealId || 'sin'}`
+


### PR DESCRIPTION
## Summary
- centralize storage key helpers
- use shared keys in form, preview, and pdf generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c71c2d64ec83289c45eecd9e53f5b5