### PR TITLE
Add favicon and update logo images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>GEP | Informes de formación (v1)</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
 
     <!-- Bootstrap 5 -->
     <link

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,7 +1,7 @@
 // src/components/Form.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import plantillasBase from '../utils/plantillas.json'
-import logoImg from '../assets/logo-gep.png'
+import logoImg from '../assets/logo-nuevo.png'
 import { triesKey, htmlKey } from '../utils/keys'
 
 const fileToDataURL = (file) =>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import logoImg from '../assets/logo-nuevo.png'
 
 export default function Home({ onSelect }) {
   return (
@@ -7,18 +8,11 @@ export default function Home({ onSelect }) {
         className="border-bottom d-flex align-items-center gap-3 sticky-top bg-white py-3 my-3"
         style={{ top: 0, zIndex: 10 }}
       >
-        <div
-          style={{
-            width: 180,
-            height: 52,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontWeight: 'bold',
-          }}
-        >
-          GEP Group
-        </div>
+        <img
+          src={logoImg}
+          alt="GEP Group"
+          style={{ width: 180, height: 52, objectFit: 'contain', display: 'block' }}
+        />
         <div className="flex-grow-1">
           <h1 className="h5 mb-0">Informes GEP</h1>
           <small className="text-muted">GEP Group — Formación y Servicios</small>

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,6 +1,6 @@
 // src/components/Preview.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import logoImg from '../assets/logo-gep.png'
+import logoImg from '../assets/logo-nuevo.png'
 import { generateReportPdfmake } from '../pdf/reportPdfmake'
 import { triesKey, htmlKey } from '../utils/keys'
 


### PR DESCRIPTION
## Summary
- link favicon in `index.html`
- switch Form, Preview, and Home components to use new `logo-nuevo.png`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d6483d7483289286d32c3501795e