### PR TITLE
Refine simulacro AI output structure and annex handling

### DIFF
--- a/netlify/functions/generateReport.js
+++ b/netlify/functions/generateReport.js
@@ -4,6 +4,209 @@ const cors = {
   'Access-Control-Allow-Headers': 'content-type',
 };
 
+const MODEL = 'gpt-4o-mini';
+
+const sanitizeContent = (content = '') =>
+  (content || '')
+    .replace(/^\s*```(?:html)?\s*/i, '')
+    .replace(/\s*```\s*$/i, '')
+    .trim();
+
+const compactText = (value) => {
+  if (value === null || value === undefined) return '';
+  const str = typeof value === 'string' ? value : String(value);
+  return str.replace(/\s+/g, ' ').trim();
+};
+
+const pickLabel = (idioma, es, ca, en) => {
+  if ((idioma || '').toUpperCase() === 'CA') return ca;
+  if ((idioma || '').toUpperCase() === 'EN') return en;
+  return es;
+};
+
+const ensureSection = (html, title) => {
+  const trimmed = sanitizeContent(html);
+  if (!trimmed) return '';
+  if (/<section[\s>]/i.test(trimmed)) return trimmed;
+  const safe = compactText(trimmed);
+  if (!safe) return '';
+  return `<section><h3>${title}</h3><p>${safe}</p></section>`;
+};
+
+const callChatCompletion = async ({ apiKey, temperature, messages }) => {
+  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature,
+      messages,
+    }),
+  });
+
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json?.error?.message || 'OpenAI error');
+  return sanitizeContent(json.choices?.[0]?.message?.content || '');
+};
+
+const buildSimulacroSystem = (idioma) => {
+  const lang = (idioma || 'ES').toUpperCase();
+  if (lang === 'EN') {
+    return 'You are a technical writer for GEP Group, expert in emergency drills. Reply in first person plural (we) with a formal PRL/PCI emergency tone. Respond only with HTML using <section>, <h3>, <h4>, <p>, <ul>, <li>. Never show numeric scores and never invent data.';
+  }
+  if (lang === 'CA') {
+    return 'Ets un redactor tècnic de GEP Group, expert en auditar simulacres. Respon sempre en primera persona del plural (nosaltres) amb to formal tècnic PRL/PCI i emergències. Respon únicament amb HTML utilitzant <section>, <h3>, <h4>, <p>, <ul>, <li>. No mostris puntuacions numèriques ni inventis dades.';
+  }
+  return 'Eres un redactor técnico de GEP Group, experto en auditar simulacros. Responde siempre en primera persona plural (nosotros) con tono formal técnico PRL/PCI y emergencias. Devuelve únicamente HTML usando <section>, <h3>, <h4>, <p>, <ul>, <li>. No muestres puntuaciones numéricas ni inventes datos.';
+};
+
+async function generarHtmlSimulacro({ apiKey, idioma, datos, formador }) {
+  const lang = (idioma || 'ES').toUpperCase();
+  const safe = (value) => {
+    const text = compactText(value);
+    return text === '' ? '-' : text;
+  };
+
+  const cronologiaArray = Array.isArray(datos?.cronologia) ? datos.cronologia : [];
+  const cronologiaJson = JSON.stringify(cronologiaArray, null, 2);
+  const cronologiaListado = cronologiaArray
+    .map((c, idx) => {
+      const hora = safe(c?.hora);
+      const texto = safe(c?.texto);
+      return `${idx + 1}. ${hora} — ${texto}`;
+    })
+    .join('\n');
+
+  const ctx = [
+    `Cliente: ${safe(datos?.cliente)}`,
+    `CIF: ${safe(datos?.cif)} | Dirección: ${safe(datos?.sede)}`,
+    `Auditor: ${safe(formador?.nombre)} | Idioma: ${lang}`,
+    `Sesiones: ${safe(datos?.sesiones)} | Duración(h): ${safe(datos?.duracion)}`,
+    '',
+    'Desarrollo propuesto:',
+    safe(datos?.desarrollo),
+    '',
+    'Cronología declarada:',
+    cronologiaListado ? `- ${cronologiaListado.split('\n').join('\n- ')}` : '- Sin cronología registrada',
+    '',
+    `Valoraciones (1-10): Participación=${datos?.escalas?.participacion ?? 0}, Compromiso=${datos?.escalas?.compromiso ?? 0}, Superación=${datos?.escalas?.superacion ?? 0}`,
+    '',
+    `Incidencias detectadas: ${safe(datos?.comentarios?.c12)}`,
+    `Accidentes: ${safe(datos?.comentarios?.c14)}`,
+    `Recomendaciones formaciones: ${safe(datos?.comentarios?.c15)}`,
+    `Recomendaciones entorno: ${safe(datos?.comentarios?.c16)}`,
+    `Recomendaciones materiales: ${safe(datos?.comentarios?.c17)}`,
+    `Observaciones generales: ${safe(datos?.comentarios?.c11)}`,
+  ]
+    .join('\n')
+    .trim();
+
+  const system = buildSimulacroSystem(idioma);
+
+  const participacion = datos?.escalas?.participacion ?? '';
+  const compromiso = datos?.escalas?.compromiso ?? '';
+  const superacion = datos?.escalas?.superacion ?? '';
+
+  const incidenciasTexto = safe(datos?.comentarios?.c12);
+  const accidentesTexto = safe(datos?.comentarios?.c14);
+  const observacionesTexto = safe(datos?.comentarios?.c11);
+  const recForm = safe(datos?.comentarios?.c15);
+  const recEntorno = safe(datos?.comentarios?.c16);
+  const recMateriales = safe(datos?.comentarios?.c17);
+  const desarrolloOriginal = safe(datos?.desarrollo);
+
+  const desarrolloTitle = pickLabel(idioma, 'DESARROLLO', 'DESENVOLUPAMENT', 'DEVELOPMENT');
+  const cronologiaTitle = pickLabel(idioma, 'CRONOLOGÍA', 'CRONOLOGIA', 'TIMELINE');
+  const incidenciasTitle = pickLabel(idioma, 'INCIDENCIAS DETECTADAS', 'INCIDÈNCIES DETECTADES', 'DETECTED INCIDENTS');
+  const observacionesTitle = pickLabel(idioma, 'OBSERVACIONES', 'OBSERVACIONS', 'OBSERVATIONS');
+  const recomendacionesTitle = pickLabel(idioma, 'RECOMENDACIONES', 'RECOMANACIONS', 'RECOMMENDATIONS');
+
+  const sections = [
+    {
+      title: desarrolloTitle,
+      temperature: 0.4,
+      instructions: [
+        `Genera la sección HTML "${desarrolloTitle}" del informe del simulacro.`,
+        '- El primer elemento debe ser un <h3> con el título exacto.',
+        `- Contenido original del campo "Desarrollo": "${desarrolloOriginal}". Resúmelo y amplíalo sin copiar literalmente.`,
+        '- Describe el escenario, el problema simulado y la respuesta que debíamos ensayar.',
+        '- Añade detalles sobre los riesgos principales y qué podía salir mal si no se seguían los procedimientos.',
+        '- Redacta en primera persona plural y no inventes datos nuevos.',
+      ].join('\n'),
+    },
+    {
+      title: cronologiaTitle,
+      temperature: 0.4,
+      instructions: [
+        `Genera la sección HTML "${cronologiaTitle}" del informe del simulacro.`,
+        '- El primer elemento debe ser un <h3> con el título exacto.',
+        '- Empieza con un <p> muy breve (máximo dos frases) que contextualice la cronología.',
+        '- Luego, crea un subapartado independiente por cada entrada de la cronología original en el mismo orden.',
+        '- Cada subapartado debe usar un <section> con un <h4> que combine la hora y un subtítulo orientado al riesgo, seguido de un <p> que detalle lo más relevante y qué podría ocurrir si se gestiona mal.',
+        '- Si no hay cronología, incluye un <p> indicando que no se registraron eventos.',
+        `Cronología original (JSON):\n${cronologiaJson}`,
+      ].join('\n'),
+    },
+    {
+      title: incidenciasTitle,
+      temperature: 0.6,
+      instructions: [
+        `Genera la sección HTML "${incidenciasTitle}".`,
+        '- El primer elemento debe ser un <h3> con el título exacto.',
+        `- Analiza las incidencias y accidentes registrados: incidencias="${incidenciasTexto}", accidentes="${accidentesTexto}".`,
+        '- Explica causas probables, impacto y riesgos de no corregirlas, enlazándolas con la cronología cuando corresponda.',
+        '- Redacta varios párrafos o una lista con <ul>/<li> si existen varios puntos críticos.',
+        '- Si no hubo incidencias, indica qué controles funcionaron y por qué.',
+      ].join('\n'),
+    },
+    {
+      title: observacionesTitle,
+      temperature: 0.7,
+      instructions: [
+        `Genera la sección HTML "${observacionesTitle}".`,
+        '- El primer elemento debe ser un <h3> con el título exacto.',
+        `- Amplía las observaciones generales (contenido: "${observacionesTexto}") con comentarios técnicos sobre coordinación, participación y tiempos de respuesta.`,
+        `- Interpreta las valoraciones numéricas en términos cualitativos (participación=${participacion}, compromiso=${compromiso}, superación=${superacion}) sin mostrar cifras.`,
+        '- Desarrolla la reflexión en varios párrafos, añadiendo matices profesionales.',
+        '- Si faltan observaciones, explica que no se registraron y justifica la ausencia con los datos disponibles.',
+      ].join('\n'),
+    },
+    {
+      title: recomendacionesTitle,
+      temperature: 0.7,
+      instructions: [
+        `Genera la sección HTML "${recomendacionesTitle}".`,
+        '- El primer elemento debe ser un <h3> con el título exacto.',
+        `- Construye recomendaciones justificadas a partir de: formaciones="${recForm}", entorno="${recEntorno}", materiales="${recMateriales}".`,
+        '- Por cada recomendación, justifica por qué es necesaria y qué riesgo mitiga; usa <ul>/<li> si precisas listar acciones.',
+        '- Mantén un enfoque proactivo orientado a la mejora continua.',
+        '- Si no se propusieron recomendaciones, sugiere un plan mínimo coherente con el contexto sin inventar datos externos.',
+      ].join('\n'),
+    },
+  ];
+
+  const htmlSections = [];
+
+  for (const section of sections) {
+    const prompt = `${section.instructions}\n\nContexto del simulacro:\n${ctx}`;
+    const content = await callChatCompletion({
+      apiKey,
+      temperature: section.temperature,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: prompt },
+      ],
+    });
+    const ensured = ensureSection(content, section.title);
+    if (ensured) htmlSections.push(ensured);
+  }
+
+  return htmlSections.join('\n');
+}
+
 // ───────── Utils mínimas (solo lo necesario) ─────────
 const normalize = (s = '') =>
   s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, ' ').trim();
@@ -38,57 +241,17 @@ export async function handler(event) {
     const fechaFmt = formatFechaDDMMYYYY(datos?.fecha || '');
     const sede = datos?.sede || '-';
     const sedeEsGEPCO = esInstalacionGEPCO(sede);
-    const sedeRedactada = sedeEsGEPCO ? `nuestras instalaciones de GEPCO (${sede})` : sede;
-
-    let ctx, system, prompt;
 
     if (tipo === 'simulacro') {
-      ctx = `
-Cliente: ${datos?.cliente || '-'}
-CIF: ${datos?.cif || '-'} | Dirección: ${datos?.sede || '-'}
-Auditor: ${formador?.nombre || '-'} | Idioma: ${idioma}
-Sesiones: ${datos?.sesiones || '-'} | Duración(h): ${datos?.duracion || '-'}
+      const html = await generarHtmlSimulacro({ apiKey: API_KEY, idioma, datos, formador });
+      return {
+        statusCode: 200,
+        headers: { 'Content-Type': 'application/json', ...cors },
+        body: JSON.stringify({ html }),
+      };
+    }
 
-Desarrollo:
-${datos?.desarrollo || '-'}
-
-Cronología:
-- ${(datos?.cronologia || []).map(c=>`${c.hora} ${c.texto}`).join('\n- ')}
-
-Valoraciones (1-10): Participación=${datos?.escalas?.participacion ?? 0}, Compromiso=${datos?.escalas?.compromiso ?? 0}, Superación=${datos?.escalas?.superacion ?? 0}
-
-Incidencias detectadas: ${datos?.comentarios?.c12 || '-'}
-Accidentes: ${datos?.comentarios?.c14 || '-'}
-Recomendaciones formaciones: ${datos?.comentarios?.c15 || '-'}
-Recomendaciones entorno: ${datos?.comentarios?.c16 || '-'}
-Recomendaciones materiales: ${datos?.comentarios?.c17 || '-'}
-Observaciones generales: ${datos?.comentarios?.c11 || '-'}
-`.trim();
-
-      system = (idioma === 'EN')
-        ? 'You are a technical writer for GEP Group, expert in emergency drills. Write in first person plural (we), formal and precise. Temperature 0.3. Never show numeric scores.'
-        : (idioma === 'CA')
-          ? 'Ets un redactor tècnic de GEP Group, expert en auditar simulacres. Escriu en primera persona del plural (nosaltres), to formal tècnic PRL/PCI i emergències. Temperatura 0.3. No mostris puntuacions numèriques.'
-          : 'Eres un redactor técnico de GEP Group, experto en auditar simulacros. Escribe en primera persona plural (nosotros), tono formal técnico PRL/PCI y emergencias. Temperatura 0.3. No muestres puntuaciones numéricas.';
-
-      prompt = `
-Redacta "Análisis y recomendaciones" del simulacro en un máximo de 650 palabras.
-Interpreta las valoraciones de forma cualitativa (alta/media/baja).
-No inventes datos y utiliza la cronología tal cual aparece, corrigiendo solo ortografía.
-
-Estructura:
-- Datos generales
-- DESARROLLO / INCIDENCIAS / RECOMENDACIONES
-- Desarrollo
-- Cronología
-- INCIDENCIAS DETECTADA
-- RECOMENDACIONES
-- OBSERVACIONES
-
-Devuelve solo el texto sin HTML.
-`.trim();
-    } else {
-      ctx = `
+    const ctx = `
 Deal: ${datos?.cliente || '-'} | CIF: ${datos?.cif || '-'}
 Sede: ${datos?.sede || '-'} | Fecha: ${datos?.fecha || '-'}
 Formador/a: ${formador?.nombre || '-'} | Idioma: ${idioma}
@@ -115,13 +278,13 @@ Comentarios:
 - Materiales: ${datos?.comentarios?.c17 || '-'}
 `.trim();
 
-      system = (idioma === 'EN')
-        ? 'You are a technical writer. Write in first person as the trainer, formal and precise. Temperature 0.3. Never show numeric scores.'
-        : (idioma === 'CA')
-          ? 'Ets un redactor tècnic. Escriu en primera persona com a formador, to formal i precís. Temperatura 0.3. No mostris puntuacions numèriques.'
-          : 'Eres un redactor técnico. Escribe en primera persona como el formador, tono formal y preciso. Temperatura 0.3. No muestres puntuaciones numéricas.';
+    const system = (idioma === 'EN')
+      ? 'You are a technical writer. Write in first person as the trainer, formal and precise. Temperature 0.3. Never show numeric scores.'
+      : (idioma === 'CA')
+        ? 'Ets un redactor tècnic. Escriu en primera persona com a formador, to formal i precís. Temperatura 0.3. No mostris puntuacions numèriques.'
+        : 'Eres un redactor técnico. Escribe en primera persona como el formador, tono formal y preciso. Temperatura 0.3. No muestres puntuaciones numéricas.';
 
-      prompt = `
+    const prompt = `
 Redacta un INFORME TÉCNICO en primera persona (yo) basado en el contexto.
 No muestres números de las escalas; interpreta en texto (“participación alta/media/baja”, etc.).
 
@@ -144,33 +307,15 @@ IMPORTANTE:
 Contexto:
 ${ctx}
 `.trim();
-    }
 
-    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        temperature: 0.3,
-        messages: [
-          { role: 'system', content: system },
-          { role: 'user', content: prompt },
-        ],
-      }),
+    const html = await callChatCompletion({
+      apiKey: API_KEY,
+      temperature: 0.3,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: prompt },
+      ],
     });
-
-    const json = await resp.json();
-    if (!resp.ok) throw new Error(json?.error?.message || 'OpenAI error');
-
-    // Sanitizar si el modelo devolviera fences por error
-    let html = json.choices?.[0]?.message?.content || '';
-    html = html
-      .replace(/^\s*```(?:html)?\s*/i, '')
-      .replace(/\s*```\s*$/i, '')
-      .trim();
 
     return {
       statusCode: 200,

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -319,8 +319,21 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
               <div className="d-grid gap-2">
                 {(datos.cronologia || []).map((p,i)=>(
                   <div className="input-group" key={i}>
-                    <input type="time" className="form-control" value={p.hora} required onChange={(e)=>updateCrono(i,'hora',e.target.value)} />
-                    <input className="form-control" value={p.texto} required onChange={(e)=>updateCrono(i,'texto',e.target.value)} />
+                    <input
+                      type="time"
+                      className="form-control"
+                      value={p.hora}
+                      required
+                      onChange={(e)=>updateCrono(i,'hora',e.target.value)}
+                      style={{ flex: '0 0 120px', maxWidth: 120 }}
+                    />
+                    <input
+                      className="form-control"
+                      value={p.texto}
+                      required
+                      onChange={(e)=>updateCrono(i,'texto',e.target.value)}
+                      style={{ flex: '1 1 auto', minWidth: 0 }}
+                    />
                     <button type="button" className="btn btn-outline-danger" onClick={()=>removeCrono(i)}>Eliminar</button>
                   </div>
                 ))}

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -296,10 +296,17 @@ export default function Preview(props) {
             </>
           )}
 
+          <hr className="my-4" />
+          <div>
+            <p className="mb-1">Atentamente,</p>
+            <strong>Jaime Martret</strong>
+            <div className="text-danger">Responsable de formaciones</div>
+          </div>
+
           {Array.isArray(imagenes) && imagenes.length > 0 && (
             <>
               <hr className="my-4" />
-              <h5 className="card-title mb-3">Imágenes de apoyo</h5>
+              <h5 className="card-title mb-3">Anexos — Imágenes de apoyo</h5>
               <div className="d-flex flex-wrap gap-2">
                 {imagenes.map((img, i) => (
                   <div key={i} className="border rounded p-1" style={{ width: 120 }}>

--- a/src/pdf/reportPdfmake.js
+++ b/src/pdf/reportPdfmake.js
@@ -149,6 +149,7 @@ const buildDocDefinition = ({
         h1: { fontSize:16, bold:true, margin:[0,0,0,6] },
         h2: { fontSize:13, bold:true, margin:[0,14,0,6], color:'#E1062C' },
         h3: { fontSize:11, bold:true, margin:[0,10,0,4] },
+        h4: { fontSize:10, bold:true, margin:[0,8,0,2] },
         small: { fontSize:9, color:'#666' },
         caption: { fontSize:8, color:'#666' },
         k: { bold:true },
@@ -231,10 +232,15 @@ const buildDocDefinition = ({
         { text: datos?.comentarios?.c17 || '—', margin:[0,0,0,4] },
         { text:'Observaciones generales', style:'h3' },
         { text: datos?.comentarios?.c11 || '—', margin:[0,0,0,8] },
-        ...(Array.isArray(imagenes) && imagenes.length ? [{ text:'Imágenes de apoyo', style:'h2', color:'#000' }, ...imageRows] : []),
         { text:'Atentamente,', margin:[0,18,0,2] },
-        { text:'Jaime', style:'k' },
+        { text:'Jaime Martret', style:'k' },
         { text:'Responsable de formaciones', color:'#E1062C', margin:[0,2,0,0] },
+        ...(Array.isArray(imagenes) && imagenes.length
+          ? [
+              { text:'Anexos — Imágenes de apoyo', style:'h2', color:'#000', margin:[0,18,0,6], pageBreak:'before' },
+              ...imageRows,
+            ]
+          : []),
       ],
     }
   }
@@ -247,6 +253,7 @@ const buildDocDefinition = ({
       h1: { fontSize: 16, bold: true, margin: [0, 0, 0, 6] },
       h2: { fontSize: 13, bold: true, margin: [0, 14, 0, 6] },
       h3: { fontSize: 11, bold: true, margin: [0, 10, 0, 4] },
+      h4: { fontSize: 10, bold: true, margin: [0, 8, 0, 2] },
       small: { fontSize: 9, color: '#666' },
       caption: { fontSize: 8, color: '#666' },
       k: { bold: true },
@@ -400,15 +407,15 @@ const buildDocDefinition = ({
         margin: [0, 0, 0, 8],
       },
 
-      // ===== Imágenes de apoyo (si hay)
-      ...(Array.isArray(imagenes) && imagenes.length
-        ? [{ text: 'Imágenes de apoyo', style: 'h2' }, ...imageRows]
-        : []),
-
       // ===== Firma
       { text: 'Atentamente,', margin: [0, 18, 0, 2] },
-      { text: 'Jaime', style: 'k' },
+      { text: 'Jaime Martret', style: 'k' },
       { text: 'Responsable de formaciones', color: '#E1062C', margin: [0, 2, 0, 0] },
+
+      // ===== Anexos (imágenes)
+      ...(Array.isArray(imagenes) && imagenes.length
+        ? [{ text: 'Anexos — Imágenes de apoyo', style: 'h2', margin: [0, 18, 0, 6], pageBreak: 'before' }, ...imageRows]
+        : []),
     ],
   }
 }


### PR DESCRIPTION
## Summary
- restructure the Netlify simulacro report generator to build structured HTML sections through dedicated OpenAI calls and updated handler logic.
- tweak the cronología editor and preview so the time field is narrower, add the new signature, and label attachments as annexes.
- adjust PDF generation styles and move images after the Jaime Martret sign-off as an annex section.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c871a82c008328a49bdfa38b7d6642