### PR TITLE
Ajustar informe de simulacros y pie de página

### DIFF
--- a/netlify/functions/generateReport.js
+++ b/netlify/functions/generateReport.js
@@ -141,9 +141,9 @@ async function generarHtmlSimulacro({ apiKey, baseUrl, idioma, datos, formador }
 
   const desarrolloTitle = pickLabel(idioma, 'DESARROLLO', 'DESENVOLUPAMENT', 'DEVELOPMENT');
   const cronologiaTitle = pickLabel(idioma, 'CRONOLOGÍA', 'CRONOLOGIA', 'TIMELINE');
-  const incidenciasTitle = pickLabel(idioma, 'INCIDENCIAS DETECTADAS', 'INCIDÈNCIES DETECTADES', 'DETECTED INCIDENTS');
-  const observacionesTitle = pickLabel(idioma, 'OBSERVACIONES', 'OBSERVACIONS', 'OBSERVATIONS');
-  const recomendacionesTitle = pickLabel(idioma, 'RECOMENDACIONES', 'RECOMANACIONS', 'RECOMMENDATIONS');
+  const contingenciasTitle = pickLabel(idioma, 'Gestión de contingencias', 'Gestió de contingències', 'Contingency management');
+  const mejoraTitle = pickLabel(idioma, 'Líneas de mejora prioritarias', 'Línies de millora prioritàries', 'Priority improvement actions');
+  const cierreTitle = pickLabel(idioma, 'Cierre de la auditoría', "Tancament de l'auditoria", 'Audit closing remarks');
 
   const sections = [
     {
@@ -155,6 +155,7 @@ async function generarHtmlSimulacro({ apiKey, baseUrl, idioma, datos, formador }
         `- Contenido original del campo "Desarrollo": "${desarrolloOriginal}". Resúmelo y amplíalo sin copiar literalmente.`,
         '- Describe el escenario, el problema simulado y la respuesta que debíamos ensayar.',
         '- Añade detalles sobre los riesgos principales y qué podía salir mal si no se seguían los procedimientos.',
+        '- Integra sólo cuando aporte valor las incidencias y accidentes registrados, evitando copiar el texto original.',
         '- Redacta en primera persona plural y no inventes datos nuevos.',
       ].join('\n'),
     },
@@ -164,47 +165,46 @@ async function generarHtmlSimulacro({ apiKey, baseUrl, idioma, datos, formador }
       instructions: [
         `Genera la sección HTML "${cronologiaTitle}" del informe del simulacro.`,
         '- El primer elemento debe ser un <h3> con el título exacto.',
-        '- Empieza con un <p> muy breve (máximo dos frases) que contextualice la cronología.',
-        '- Luego, crea un subapartado independiente por cada entrada de la cronología original en el mismo orden.',
-        '- Cada subapartado debe usar un <section> con un <h4> que combine la hora y un subtítulo orientado al riesgo, seguido de un <p> que detalle lo más relevante y qué podría ocurrir si se gestiona mal.',
-        '- Si no hay cronología, incluye un <p> indicando que no se registraron eventos.',
+        '- Recuerda que la cronología detallada ya figura en el documento antes de este bloque.',
+        '- Redacta únicamente un resumen crítico en uno o dos párrafos que destaque hitos, tiempos de respuesta y riesgos detectados.',
+        '- No enumeres de nuevo cada evento ni crees listas; céntrate en conclusiones e insights.',
+        '- Si no hay cronología, explica por qué no se registraron eventos y cómo afecta al análisis.',
         `Cronología original (JSON):\n${cronologiaJson}`,
       ].join('\n'),
     },
     {
-      title: incidenciasTitle,
+      title: contingenciasTitle,
       temperature: 0.6,
       instructions: [
-        `Genera la sección HTML "${incidenciasTitle}".`,
+        `Genera la sección HTML "${contingenciasTitle}".`,
         '- El primer elemento debe ser un <h3> con el título exacto.',
-        `- Analiza las incidencias y accidentes registrados: incidencias="${incidenciasTexto}", accidentes="${accidentesTexto}".`,
-        '- Explica causas probables, impacto y riesgos de no corregirlas, enlazándolas con la cronología cuando corresponda.',
-        '- Redacta varios párrafos o una lista con <ul>/<li> si existen varios puntos críticos.',
-        '- Si no hubo incidencias, indica qué controles funcionaron y por qué.',
+        `- Analiza cómo se gestionaron incidencias y accidentes: incidencias="${incidenciasTexto}", accidentes="${accidentesTexto}".`,
+        '- Relaciona cada situación con la cronología y el impacto en la seguridad, señalando controles aplicados y riesgos mitigados.',
+        '- Usa párrafos o una lista corta (<ul>/<li>) solo si ayuda a ordenar varios focos críticos.',
+        '- Si no hubo incidencias relevantes, explica qué controles preventivos funcionaron y qué indicadores lo demuestran.',
       ].join('\n'),
     },
     {
-      title: observacionesTitle,
+      title: mejoraTitle,
       temperature: 0.7,
       instructions: [
-        `Genera la sección HTML "${observacionesTitle}".`,
+        `Genera la sección HTML "${mejoraTitle}".`,
         '- El primer elemento debe ser un <h3> con el título exacto.',
-        `- Amplía las observaciones generales (contenido: "${observacionesTexto}") con comentarios técnicos sobre coordinación, participación y tiempos de respuesta.`,
-        `- Interpreta las valoraciones numéricas en términos cualitativos (participación=${participacion}, compromiso=${compromiso}, superación=${superacion}) sin mostrar cifras.`,
-        '- Desarrolla la reflexión en varios párrafos, añadiendo matices profesionales.',
-        '- Si faltan observaciones, explica que no se registraron y justifica la ausencia con los datos disponibles.',
+        `- Fundamenta cada línea de mejora a partir de las propuestas registradas: formaciones="${recForm}", entorno="${recEntorno}", materiales="${recMateriales}".`,
+        '- Reformula y sintetiza estas ideas sin copiar literalmente los textos originales.',
+        '- Explica qué riesgo o brecha cubre cada acción y qué prioridad debería tener.',
+        '- Añade, si procede, observaciones profesionales que refuercen la necesidad de implantarlas.',
       ].join('\n'),
     },
     {
-      title: recomendacionesTitle,
-      temperature: 0.7,
+      title: cierreTitle,
+      temperature: 0.5,
       instructions: [
-        `Genera la sección HTML "${recomendacionesTitle}".`,
+        `Genera la sección HTML "${cierreTitle}".`,
         '- El primer elemento debe ser un <h3> con el título exacto.',
-        `- Construye recomendaciones justificadas a partir de: formaciones="${recForm}", entorno="${recEntorno}", materiales="${recMateriales}".`,
-        '- Por cada recomendación, justifica por qué es necesaria y qué riesgo mitiga; usa <ul>/<li> si precisas listar acciones.',
-        '- Mantén un enfoque proactivo orientado a la mejora continua.',
-        '- Si no se propusieron recomendaciones, sugiere un plan mínimo coherente con el contexto sin inventar datos externos.',
+        `- Sintetiza la evaluación cualitativa interpretando las valoraciones: participación=${participacion}, compromiso=${compromiso}, superación=${superacion} (sin mencionar números).`,
+        `- Integra las observaciones generales registradas ("${observacionesTexto}") para reforzar la conclusión.`,
+        '- Cierra con una valoración global del simulacro y los próximos pasos inmediatos desde la perspectiva del auditor.',
       ].join('\n'),
     },
   ];

--- a/src/pdf/reportPdfmake.js
+++ b/src/pdf/reportPdfmake.js
@@ -141,6 +141,60 @@ const buildDocDefinition = ({
   }))
 
   if (datos?.tipo === 'simulacro') {
+    const footerSimulacro = () => ({
+      margin: [58, 0, 58, 18],
+      stack: [
+        {
+          table: {
+            widths: ['*', '*', '*'],
+            body: [
+              [
+                {
+                  stack: [
+                    { text: 'BARCELONA', color: '#E1062C', bold: true, fontSize: 9 },
+                    { text: 'C. Moratín, 100 · 08206 Sabadell · Barcelona', fontSize: 8 },
+                    { text: 'Tel. +34 935 604 636', fontSize: 8 },
+                  ],
+                },
+                {
+                  stack: [
+                    { text: 'MADRID', color: '#E1062C', bold: true, fontSize: 9 },
+                    { text: 'C. Primavera, 1 · 28500 Arganda del Rey · Madrid', fontSize: 8 },
+                    { text: 'Tel. +34 918 283 898', fontSize: 8 },
+                  ],
+                },
+                {
+                  stack: [
+                    { text: 'CÁDIZ', color: '#E1062C', bold: true, fontSize: 9 },
+                    { text: 'C. Hungría, 11 Nave 1B · 11011 Cádiz', fontSize: 8 },
+                    { text: ' ', fontSize: 8 },
+                  ],
+                },
+              ],
+            ],
+          },
+          columnGap: 18,
+          layout: {
+            hLineWidth: () => 0,
+            vLineWidth: () => 0,
+            paddingLeft: () => 8,
+            paddingRight: () => 8,
+            paddingTop: () => 6,
+            paddingBottom: () => 6,
+            fillColor: () => '#F5F5F5',
+          },
+        },
+        {
+          text: 'www.gepservices.es',
+          alignment: 'right',
+          color: '#E1062C',
+          bold: true,
+          margin: [0, 6, 0, 0],
+          fontSize: 9,
+        },
+      ],
+    });
+
     return {
       pageSize: 'A4',
       pageMargins: [58,110,58,90],
@@ -155,7 +209,7 @@ const buildDocDefinition = ({
         k: { bold:true },
       },
       header: () => ({ image: headerDataUrl, width:479, alignment:'center', margin:[0,18,0,0] }),
-      footer: () => ({ image: footerDataUrl, width:479, alignment:'center', margin:[0,0,0,18] }),
+      footer: footerSimulacro,
       content: [
         { text: 'INFORME SIMULACRO', style:'h1' },
         { text: [{ text:'Fecha del simulacro: ', bold:true }, { text: datos?.fecha || '—' }], margin:[0,0,0,6] },
@@ -198,7 +252,7 @@ const buildDocDefinition = ({
           layout:{ hLineWidth:()=>0, vLineWidth:()=>0, paddingTop:()=>0, paddingBottom:()=>0, paddingLeft:()=>0, paddingRight:()=>0 },
           margin:[0,8,0,0],
         },
-        { text:'DESARROLLO / INCIDENCIAS / RECOMENDACIONES', style:'h2' },
+        { text:'DESARROLLO Y ANÁLISIS', style:'h2' },
         { text:'Desarrollo', style:'h3' },
         { text: datos?.desarrollo || '—', margin:[0,0,0,6] },
         { text:'Cronología', style:'h3' },
@@ -220,18 +274,6 @@ const buildDocDefinition = ({
           layout:'lightHorizontalLines',
           margin:[0,0,0,8],
         },
-        { text:'Incidencias detectadas', style:'h3' },
-        { text: datos?.comentarios?.c12 || '—', margin:[0,0,0,4] },
-        { text:'Accidentes', style:'h3' },
-        { text: datos?.comentarios?.c14 || '—', margin:[0,0,0,4] },
-        { text:'Recomendaciones: Formaciones', style:'h3' },
-        { text: datos?.comentarios?.c15 || '—', margin:[0,0,0,4] },
-        { text:'Recomendaciones: Del entorno de Trabajo', style:'h3' },
-        { text: datos?.comentarios?.c16 || '—', margin:[0,0,0,4] },
-        { text:'Recomendaciones: De Materiales', style:'h3' },
-        { text: datos?.comentarios?.c17 || '—', margin:[0,0,0,4] },
-        { text:'Observaciones generales', style:'h3' },
-        { text: datos?.comentarios?.c11 || '—', margin:[0,0,0,8] },
         { text:'Atentamente,', margin:[0,18,0,2] },
         { text:'Jaime Martret', style:'k' },
         { text:'Responsable de formaciones', color:'#E1062C', margin:[0,2,0,0] },


### PR DESCRIPTION
## Summary
- Ajusta el prompt del simulacro para que la IA use los comentarios como contexto, añada un resumen de la cronología y cierre con análisis cualitativo.
- Actualiza la maquetación del PDF de simulacros para finalizar tras la evaluación, mantener la firma y anexos y aplicar el nuevo pie con direcciones de contacto.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c97ed7a7108328b65aaab21cc0cefc