### PR TITLE
Align preventivo report experience with new brief

### DIFF
--- a/netlify/functions/generateReport.js
+++ b/netlify/functions/generateReport.js
@@ -117,38 +117,38 @@ const preventivoHeadings = {
   },
 };
 
+const preventivoSignature = {
+  ES: 'Jaime Martret. Responsable de formaciones',
+  CA: 'Jaime Martret. Responsable de formacions',
+  EN: 'Jaime Martret. Head of Training',
+};
+
 const buildPreventivoSystem = (idioma) => {
   const lang = (idioma || 'ES').toUpperCase();
   if (lang === 'EN') {
     return [
-      'You are a technical writer for GEP Group, specialised in auditing preventive emergency drills executed by private firefighters.',
-      'Write in first-person plural (we) as the team reporting to the customer after the exercise.',
-      'Adopt a formal PRL/PCI emergency tone: precise, clear and without embellishment, keeping a medium creative temperature.',
-      'Never invent information. Interpret only the provided context, correcting grammar and spelling issues.',
-      'Return plain text only (no HTML or Markdown).',
-      'Respect exactly the supplied headings, one per line. The sections “Works performed”, “Tasks”, “Observations” and “Incidents” must each contain between 350 and 450 words.',
-      'After the corporate signature “Jaime Martret. Head of Training”, state that the image annex follows the signature.',
+      'You are a technical writer for GEP Group, specialised in preventive emergency drills.',
+      'Always write in first-person plural (we) with a formal PRL/PCI emergency tone: precise, direct and without embellishment.',
+      'Do not invent information. Correct grammar and spelling. Output plain text only, no HTML.',
+      'Use exactly the headings provided, one per line, and keep the sections “Works performed”, “Tasks”, “Observations” and “Incidents” between 350 and 450 words each.',
+      'Close with the corporate signature “Jaime Martret. Head of Training” and mention the image annex after the signature.',
     ].join('\n');
   }
   if (lang === 'CA') {
     return [
-      'Ets un redactor tècnic de GEP Group expert en auditar exercicis preventius realitzats per bombers privats.',
-      'Escriu sempre en primera persona del plural (nosaltres) com a equip que informa al client després de l’exercici.',
-      'Mantén un to formal tècnic PRL/PCI i emergències: precís, clar i sense floritures, amb una temperatura creativa mitjana.',
-      'No inventis dades. Treballa només amb el context disponible i corregeix ortografia i gramàtica.',
-      'Respon exclusivament amb text pla, sense HTML ni Markdown.',
-      'Respecta exactament els encapçalaments indicats, un per línia. Les seccions “Treballs”, “Tasques”, “Observacions” i “Incidències” han de tenir entre 350 i 450 paraules cadascuna.',
-      'Després de la signatura corporativa “Jaime Martret. Responsable de formacions”, indica que l’annex d’imatges s’adjunta a continuació.',
+      'Ets un redactor tècnic de GEP Group especialitzat en exercicis preventius.',
+      'Escriu sempre en primera persona del plural (nosaltres) amb to formal tècnic PRL/PCI: precís, directe i sense floritures.',
+      'No inventis dades. Corregeix ortografia i gramàtica. Respon només amb text pla, sense HTML.',
+      'Fes servir exactament els encapçalaments indicats, un per línia, i mantén les seccions “Treballs”, “Tasques”, “Observacions” i “Incidències” entre 350 i 450 paraules cadascuna.',
+      'Tanca amb la signatura corporativa “Jaime Martret. Responsable de formacions” i cita l’annex d’imatges després de la signatura.',
     ].join('\n');
   }
   return [
-    'Eres un redactor técnico de GEP Group, experto en auditar ejercicios preventivos realizados por bomberos privados.',
-    'Escribe siempre en primera persona del plural (nosotros) como el equipo que informa al cliente tras el ejercicio.',
-    'Mantén un tono formal técnico PRL/PCI y emergencias: preciso, claro y sin florituras, con una temperatura creativa media.',
-    'No inventes datos. Trabaja únicamente con el contexto entregado y corrige ortografía y gramática.',
-    'Devuelve solo texto plano, sin HTML ni Markdown.',
-    'Respeta exactamente los encabezados indicados, uno por línea. Las secciones “Trabajos”, “Tareas”, “Observaciones” e “Incidencias” deben tener entre 350 y 450 palabras cada una.',
-    'Tras la firma corporativa “Jaime Martret. Responsable de formaciones”, indica que el anexo de imágenes se adjunta a continuación.',
+    'Eres un redactor técnico de GEP Group especializado en ejercicios preventivos.',
+    'Escribe siempre en primera persona del plural (nosotros) con un tono formal técnico PRL/PCI: preciso, directo y sin florituras.',
+    'No inventes datos. Corrige ortografía y gramática. Devuelve únicamente texto plano, sin HTML.',
+    'Utiliza exactamente los encabezados indicados, uno por línea, y mantén las secciones “Trabajos”, “Tareas”, “Observaciones” e “Incidencias” entre 350 y 450 palabras cada una.',
+    'Cierra con la firma corporativa “Jaime Martret. Responsable de formaciones” y menciona el anexo de imágenes después de la firma.',
   ].join('\n');
 };
 
@@ -300,6 +300,8 @@ async function generarInformePreventivo({ apiKey, baseUrl, idioma, datos, formad
   const lang = (idioma || 'ES').toUpperCase();
   const headings = preventivoHeadings[lang] || preventivoHeadings.ES;
   const system = buildPreventivoSystem(lang);
+  const signature = preventivoSignature[lang] || preventivoSignature.ES;
+  const idiomaNombre = lang === 'EN' ? 'inglés' : lang === 'CA' ? 'catalán' : 'castellano';
 
   const safe = (value) => {
     if (value === null || value === undefined) return '-';
@@ -348,8 +350,9 @@ Indicaciones:
 - Reescribe "${headings.trabajos}", "${headings.tareas}", "${headings.observaciones}" e "${headings.incidencias}" con una extensión de entre 350 y 450 palabras por sección, interpretando profesionalmente el material original.
 - No inventes datos: si falta información, explica el impacto en el análisis.
 - Corrige ortografía y gramática manteniendo el tono formal PRL/PCI y la primera persona plural (nosotros).
-- En "${headings.firma}" utiliza literalmente “Jaime Martret. Responsable de formaciones”.
+- En "${headings.firma}" utiliza literalmente “${signature}”.
 - En "${headings.anexos}" indica que las imágenes se adjuntan como anexo posterior a la firma.
+- Redacta el informe íntegramente en ${idiomaNombre}.
 
 Contexto disponible:
 ${contexto}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,7 @@ export default function App() {
       {screen === 'preventivo-form' && (
         <Form
           initial={preventivo}
-          title="Informe de Preventivo"
+          title="Informe de Preventivos"
           type="preventivo"
           onChooseAnother={() => setScreen('home')}
           onNext={(data) => {
@@ -70,7 +70,7 @@ export default function App() {
       {screen === 'preventivo-preview' && (
         <Preview
           data={preventivo}
-          title="Informe de Preventivo"
+          title="Informe de Preventivos"
           type="preventivo"
           onBack={() => setScreen('preventivo-form')}
         />

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -151,13 +151,15 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
       return Number.isFinite(n) && n > 0
     }
 
-    const numericChecks = [
-      { applies: isSimulacro || isFormacion, value: datos.sesiones },
-      { applies: isFormacion, value: datos.alumnos },
-      { applies: isSimulacro || isFormacion, value: datos.duracion },
-    ]
-
-    if (numericChecks.some((check) => check.applies && !numOk(check.value))) {
+    if ((isSimulacro || isFormacion) && !numOk(datos.sesiones)) {
+      alert('Los campos numéricos deben ser mayores que 0.')
+      return
+    }
+    if (isFormacion && !numOk(datos.alumnos)) {
+      alert('Los campos numéricos deben ser mayores que 0.')
+      return
+    }
+    if ((isSimulacro || isFormacion) && !numOk(datos.duracion)) {
       alert('Los campos numéricos deben ser mayores que 0.')
       return
     }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -16,11 +16,21 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
   const formRef = useRef(null)
 
   const isSimulacro = type === 'simulacro'
+  const isPreventivo = type === 'preventivo'
+  const isFormacion = type === 'formacion'
 
   const [dealId, setDealId] = useState(initial?.dealId || '')
   const prevDealIdRef = useRef(dealId)
 
-  const [datos, setDatos] = useState({
+  const defaultComentarios = initial?.datos?.comentarios || { c11: '', c12: '', c13: '', c14: '', c15: '', c16: '', c17: '' }
+  const defaultPreventivo = initial?.datos?.preventivo || {
+    trabajos: initial?.datos?.comentarios?.c11 || '',
+    tareas: initial?.datos?.comentarios?.c12 || '',
+    observaciones: initial?.datos?.comentarios?.c13 || '',
+    incidencias: initial?.datos?.comentarios?.c14 || '',
+  }
+
+  const [datos, setDatos] = useState(() => ({
     cliente: initial?.datos?.cliente || '',
     cif: initial?.datos?.cif || '',
     direccionOrg: initial?.datos?.direccionOrg || '',
@@ -39,11 +49,12 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
     desarrollo: initial?.datos?.desarrollo || '',
     cronologia: initial?.datos?.cronologia || [],
     escalas: initial?.datos?.escalas || { participacion: 7, compromiso: 7, superacion: 7 },
-    comentarios: initial?.datos?.comentarios || { c11:'', c12:'', c13:'', c14:'', c15:'', c16:'', c17:'' },
-  })
+    comentarios: defaultComentarios,
+    preventivo: defaultPreventivo,
+  }))
 
   const [imagenes, setImagenes] = useState(initial?.imagenes || [])
-  const [selTitulo, setSelTitulo] = useState(datos.formacionTitulo || '')
+  const [selTitulo, setSelTitulo] = useState(isFormacion ? (datos.formacionTitulo || '') : '')
   const [loadingDeal, setLoadingDeal] = useState(false)
 
   // Reset de intentos/HTML si cambia el dealId
@@ -59,7 +70,7 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
 
   // Cargar plantilla al seleccionar formación
   useEffect(() => {
-    if (!selTitulo) return
+    if (!isFormacion || !selTitulo) return
     const p = plantillasBase[selTitulo]
     setDatos(d => ({
       ...d,
@@ -67,7 +78,7 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
       contenidoTeorica: p?.teorica || [],
       contenidoPractica: p?.practica || [],
     }))
-  }, [selTitulo])
+  }, [selTitulo, isFormacion])
 
   // Pipedrive
   const rellenarDesdePipedrive = async () => {
@@ -139,16 +150,41 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
       const n = Number(v)
       return Number.isFinite(n) && n > 0
     }
-    if (!numOk(datos.sesiones) || (!isSimulacro && !numOk(datos.alumnos)) || !numOk(datos.duracion)) {
+
+    const numericChecks = [
+      { applies: isSimulacro || isFormacion, value: datos.sesiones },
+      { applies: isFormacion, value: datos.alumnos },
+      { applies: isSimulacro || isFormacion, value: datos.duracion },
+    ]
+
+    if (numericChecks.some((check) => check.applies && !numOk(check.value))) {
       alert('Los campos numéricos deben ser mayores que 0.')
       return
     }
+
     if (!datos.fecha) {
       alert('La fecha es obligatoria.')
       return
     }
 
-    onNext({ type, dealId, formador: { nombre: datos.formadorNombre, idioma: datos.idioma }, datos: { ...datos, tipo: type }, imagenes })
+    const nextDatos = {
+      ...datos,
+      tipo: type,
+      comentarios: isPreventivo
+        ? {
+            ...datos.comentarios,
+            c11: datos.preventivo?.trabajos || '',
+            c12: datos.preventivo?.tareas || '',
+            c13: datos.preventivo?.observaciones || '',
+            c14: datos.preventivo?.incidencias || '',
+            c15: '',
+            c16: '',
+            c17: '',
+          }
+        : datos.comentarios,
+    }
+
+    onNext({ type, dealId, formador: { nombre: datos.formadorNombre, idioma: datos.idioma }, datos: nextDatos, imagenes })
   }
 
   const addTeorica = () => setDatos(d => ({ ...d, contenidoTeorica: [...(d.contenidoTeorica||[]), '' ] }))
@@ -157,6 +193,164 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
   const opcionesOrdenadas = useMemo(() =>
     Object.keys(plantillasBase).sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
   , [])
+
+  const renderContenidoEspecifico = () => {
+    if (isSimulacro) {
+      return (
+        <>
+          <h2 className="h5 text-danger">DESARROLLO / INCIDENCIAS / RECOMENDACIONES</h2>
+          <div className="mb-3">
+            <label className="form-label">Desarrollo</label>
+            <textarea className="form-control" required value={datos.desarrollo} onChange={(e)=>setDatos(d=>({...d, desarrollo:e.target.value}))} />
+          </div>
+          <div>
+            <h2 className="h5">Cronología</h2>
+            <div className="card"><div className="card-body">
+              <label className="form-label">Inicio del Simulacro</label>
+              <div className="d-grid gap-2">
+                {(datos.cronologia || []).map((p,i)=>(
+                  <div className="input-group" key={i}>
+                    <input
+                      type="time"
+                      className="form-control"
+                      value={p.hora}
+                      required
+                      onChange={(e)=>updateCrono(i,'hora',e.target.value)}
+                      style={{ flex: '0 0 120px', maxWidth: 120 }}
+                    />
+                    <input
+                      className="form-control"
+                      value={p.texto}
+                      required
+                      onChange={(e)=>updateCrono(i,'texto',e.target.value)}
+                      style={{ flex: '1 1 auto', minWidth: 0 }}
+                    />
+                    <button type="button" className="btn btn-outline-danger" onClick={()=>removeCrono(i)}>Eliminar</button>
+                  </div>
+                ))}
+                <button type="button" className="btn btn-outline-primary" onClick={addCrono}>Añadir punto</button>
+              </div>
+              <div className="form-text mt-2">Añade punto a punto la cronología de lo que sucede en el simulacro</div>
+            </div></div>
+          </div>
+        </>
+      )
+    }
+
+    if (isPreventivo) {
+      const updatePreventivo = (field, value) => {
+        setDatos(d => ({
+          ...d,
+          preventivo: { ...d.preventivo, [field]: value },
+        }))
+      }
+
+      const sections = [
+        { key: 'trabajos', title: 'Trabajos' },
+        { key: 'tareas', title: 'Tareas' },
+        { key: 'observaciones', title: 'Observaciones' },
+        { key: 'incidencias', title: 'Incidencias' },
+      ]
+
+      return (
+        <section className="d-grid gap-3">
+          <h2 className="h5 mb-0">Secciones del informe preventivo</h2>
+          <div className="card">
+            <div className="card-body d-grid gap-4">
+              {sections.map(({ key, title }) => (
+                <div key={key} className="d-grid gap-2">
+                  <h3 className="h6 text-uppercase text-muted mb-0">{title}</h3>
+                  <textarea
+                    className="form-control"
+                    required
+                    rows={10}
+                    style={{ minHeight: 200 }}
+                    value={datos.preventivo?.[key] || ''}
+                    onChange={(e)=>updatePreventivo(key, e.target.value)}
+                  />
+                </div>
+              ))}
+
+              <div className="d-grid gap-2">
+                <h3 className="h6 text-uppercase text-muted mb-0">Imágenes de apoyo (opcional)</h3>
+                <input type="file" accept="image/*" multiple className="form-control" onChange={addImagenes} />
+                {imagenes.length > 0 && (
+                  <div className="mt-2 d-flex flex-wrap gap-2">
+                    {imagenes.map((img, idx) => (
+                      <div key={idx} className="border rounded p-1" style={{ width: 120 }}>
+                        <img src={img.dataUrl} alt={img.name} className="img-fluid rounded" />
+                        <div className="d-flex justify-content-between align-items-center mt-1">
+                          <small className="text-truncate" style={{ maxWidth: 80 }} title={img.name}>{img.name}</small>
+                          <button type="button" className="btn btn-sm btn-outline-danger" onClick={()=>removeImagen(idx)}>x</button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="form-text">Se añadirán al final del informe como anexo tras la firma.</div>
+              </div>
+            </div>
+          </div>
+        </section>
+      )
+    }
+
+    return (
+      <div>
+        <h2 className="h5">Formación realizada</h2>
+        <div className="card"><div className="card-body">
+          <div className="row g-3">
+            <div className="col-md-6">
+              <label className="form-label">Formación</label>
+              <select
+                className="form-select"
+                value={selTitulo}
+                required
+                onChange={(e)=>setSelTitulo(e.target.value)}
+              >
+                <option value="">— Selecciona —</option>
+                {opcionesOrdenadas.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div className="row g-4 mt-1">
+            <div className="col-md-6">
+              <label className="form-label">Parte Teórica</label>
+              <div className="d-grid gap-2">
+                {(datos.contenidoTeorica || []).map((v,i)=>(
+                  <div className="input-group" key={`t-${i}`}>
+                    <input className="form-control" value={v}
+                      onChange={(e)=>setDatos(d=>{ const arr=[...(d.contenidoTeorica||[])]; arr[i]=e.target.value; return {...d, contenidoTeorica:arr}; })} />
+                    <button type="button" className="btn btn-outline-danger" onClick={()=>setDatos(d=>({...d, contenidoTeorica:d.contenidoTeorica.filter((_,idx)=>idx!==i)}))}>Eliminar</button>
+                  </div>
+                ))}
+                <button type="button" className="btn btn-outline-primary" onClick={addTeorica}>Añadir punto</button>
+              </div>
+            </div>
+
+            <div className="col-md-6">
+              <label className="form-label">Parte Práctica</label>
+              <div className="d-grid gap-2">
+                {(datos.contenidoPractica || []).map((v,i)=>(
+                  <div className="input-group" key={`p-${i}`}>
+                    <input className="form-control" value={v}
+                      onChange={(e)=>setDatos(d=>{ const arr=[...(d.contenidoPractica||[])]; arr[i]=e.target.value; return {...d, contenidoPractica:arr}; })} />
+                    <button type="button" className="btn btn-outline-danger" onClick={()=>setDatos(d=>({...d, contenidoPractica:d.contenidoPractica.filter((_,idx)=>idx!==i)}))}>Eliminar</button>
+                  </div>
+                ))}
+                <button type="button" className="btn btn-outline-primary" onClick={addPractica}>Añadir punto</button>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-text mt-2">
+            Selecciona la formación realizada. Se añadirán sus “Parte teórica” y “Parte práctica” al borrador. Si falta algún punto, añádelo.
+          </div>
+        </div></div>
+      </div>
+    )
+  }
 
   return (
     <form ref={formRef} className="d-grid gap-4" onSubmit={onSubmit}>
@@ -215,7 +409,7 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
                   <input className="form-control" value={datos.direccionOrg} required onChange={(e)=>setDatos(d=>({...d, direccionOrg:e.target.value}))} />
                 </div>
                 <div className="col-md-6">
-                  <label className="form-label">{isSimulacro ? 'Dirección del Simulacro' : 'Dirección de la formación'}</label>
+                  <label className="form-label">{(isSimulacro || isPreventivo) ? 'Dirección del Simulacro' : 'Dirección de la formación'}</label>
                   <input className="form-control" value={datos.sede} required onChange={(e)=>setDatos(d=>({...d, sede:e.target.value}))} />
                 </div>
               </div>
@@ -223,16 +417,16 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
           </div>
         </div>
 
-        {/* DATOS DEL FORMADOR */}
+        {/* DATOS DEL FORMADOR / REGISTRO */}
         <div className="col-md-6 d-flex">
           <div className="card w-100 h-100">
             <div className="card-body">
-              <h2 className="h6">Datos del formador</h2>
+              <h2 className="h6">{isPreventivo ? 'Registro' : (isSimulacro ? 'Datos del auditor' : 'Datos del formador')}</h2>
 
               <div className="row g-3">
                 {/* Formador/a o Auditor/a */}
                 <div className="col-12">
-                  <label className="form-label">{isSimulacro ? 'Auditor/a' : 'Formador/a'}</label>
+                  <label className="form-label">{isPreventivo ? 'Bombero/a' : (isSimulacro ? 'Auditor/a' : 'Formador/a')}</label>
                   <input className="form-control" value={datos.formadorNombre} required onChange={(e)=>setDatos(d=>({...d, formadorNombre:e.target.value}))} />
                 </div>
 
@@ -248,7 +442,7 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
 
                 {/* Fecha */}
                 <div className="col-12 col-md-6">
-                  <label className="form-label">Fecha</label>
+                  <label className="form-label">{isPreventivo ? 'Fecha ejercicio' : 'Fecha'}</label>
                   <input
                     type="date"
                     className="form-control"
@@ -258,151 +452,60 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
                   />
                 </div>
 
-                {/* Sesiones */}
-                <div className="col-12 col-md-6">
-                  <label className="form-label">Sesiones</label>
-                  <input
-                    type="number"
-                    min={1}
-                    className="form-control"
-                    value={datos.sesiones}
-                    required
-                    onChange={(e)=>setDatos(d=>({...d, sesiones:Number(e.target.value||1)}))}
-                  />
-                </div>
+                {!isPreventivo && (
+                  <>
+                    <div className="col-12 col-md-6">
+                      <label className="form-label">Sesiones</label>
+                      <input
+                        type="number"
+                        min={1}
+                        className="form-control"
+                        value={datos.sesiones}
+                        required
+                        onChange={(e)=>setDatos(d=>({...d, sesiones:Number(e.target.value||1)}))}
+                      />
+                    </div>
 
-                {/* Nº alumnos (solo formación) */}
-                {!isSimulacro && (
-                  <div className="col-12 col-md-6">
-                    <label className="form-label">Nº de alumnos</label>
-                    <input
-                      type="number"
-                      min={1}
-                      className="form-control"
-                      value={datos.alumnos}
-                      required={!isSimulacro}
-                      onChange={(e)=>setDatos(d=>({...d, alumnos:e.target.value}))}
-                    />
-                  </div>
+                    {!isSimulacro && (
+                      <div className="col-12 col-md-6">
+                        <label className="form-label">Nº de alumnos</label>
+                        <input
+                          type="number"
+                          min={1}
+                          className="form-control"
+                          value={datos.alumnos}
+                          required={!isSimulacro}
+                          onChange={(e)=>setDatos(d=>({...d, alumnos:e.target.value}))}
+                        />
+                      </div>
+                    )}
+
+                    <div className="col-12 col-md-6">
+                      <label className="form-label">Duración (horas)</label>
+                      <input
+                        type="number"
+                        min={1}
+                        step="0.5"
+                        className="form-control"
+                        value={datos.duracion}
+                        required
+                        onChange={(e)=>setDatos(d=>({...d, duracion:e.target.value}))}
+                      />
+                    </div>
+                  </>
                 )}
-
-                {/* Duración (numérico) */}
-                <div className="col-12 col-md-6">
-                  <label className="form-label">Duración (horas)</label>
-                  <input
-                    type="number"
-                    min={1}
-                    step="0.5"
-                    className="form-control"
-                    value={datos.duracion}
-                    required
-                    onChange={(e)=>setDatos(d=>({...d, duracion:e.target.value}))}
-                  />
-                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      {isSimulacro ? (
-        <>
-          <h2 className="h5 text-danger">DESARROLLO / INCIDENCIAS / RECOMENDACIONES</h2>
-          <div className="mb-3">
-            <label className="form-label">Desarrollo</label>
-            <textarea className="form-control" required value={datos.desarrollo} onChange={(e)=>setDatos(d=>({...d, desarrollo:e.target.value}))} />
-          </div>
-          <div>
-            <h2 className="h5">Cronología</h2>
-            <div className="card"><div className="card-body">
-              <label className="form-label">Inicio del Simulacro</label>
-              <div className="d-grid gap-2">
-                {(datos.cronologia || []).map((p,i)=>(
-                  <div className="input-group" key={i}>
-                    <input
-                      type="time"
-                      className="form-control"
-                      value={p.hora}
-                      required
-                      onChange={(e)=>updateCrono(i,'hora',e.target.value)}
-                      style={{ flex: '0 0 120px', maxWidth: 120 }}
-                    />
-                    <input
-                      className="form-control"
-                      value={p.texto}
-                      required
-                      onChange={(e)=>updateCrono(i,'texto',e.target.value)}
-                      style={{ flex: '1 1 auto', minWidth: 0 }}
-                    />
-                    <button type="button" className="btn btn-outline-danger" onClick={()=>removeCrono(i)}>Eliminar</button>
-                  </div>
-                ))}
-                <button type="button" className="btn btn-outline-primary" onClick={addCrono}>Añadir punto</button>
-              </div>
-              <div className="form-text mt-2">Añade punto a punto la cronología de lo que sucede en el simulacro</div>
-            </div></div>
-          </div>
-        </>
-      ) : (
+      {renderContenidoEspecifico()}
+
+      {!isPreventivo && (
         <div>
-          <h2 className="h5">Formación realizada</h2>
+          <h2 className="h5">Valoración</h2>
           <div className="card"><div className="card-body">
-            <div className="row g-3">
-              <div className="col-md-6">
-                <label className="form-label">Formación</label>
-                <select
-                  className="form-select"
-                  value={selTitulo}
-                  required
-                  onChange={(e)=>setSelTitulo(e.target.value)}
-                >
-                  <option value="">— Selecciona —</option>
-                  {opcionesOrdenadas.map(t => <option key={t} value={t}>{t}</option>)}
-                </select>
-              </div>
-            </div>
-
-            <div className="row g-4 mt-1">
-              <div className="col-md-6">
-                <label className="form-label">Parte Teórica</label>
-                <div className="d-grid gap-2">
-                  {(datos.contenidoTeorica || []).map((v,i)=>(
-                    <div className="input-group" key={`t-${i}`}>
-                      <input className="form-control" value={v}
-                        onChange={(e)=>setDatos(d=>{ const arr=[...(d.contenidoTeorica||[])]; arr[i]=e.target.value; return {...d, contenidoTeorica:arr}; })} />
-                      <button type="button" className="btn btn-outline-danger" onClick={()=>setDatos(d=>({...d, contenidoTeorica:d.contenidoTeorica.filter((_,idx)=>idx!==i)}))}>Eliminar</button>
-                    </div>
-                  ))}
-                  <button type="button" className="btn btn-outline-primary" onClick={addTeorica}>Añadir punto</button>
-                </div>
-              </div>
-
-              <div className="col-md-6">
-                <label className="form-label">Parte Práctica</label>
-                <div className="d-grid gap-2">
-                  {(datos.contenidoPractica || []).map((v,i)=>(
-                    <div className="input-group" key={`p-${i}`}>
-                      <input className="form-control" value={v}
-                        onChange={(e)=>setDatos(d=>{ const arr=[...(d.contenidoPractica||[])]; arr[i]=e.target.value; return {...d, contenidoPractica:arr}; })} />
-                      <button type="button" className="btn btn-outline-danger" onClick={()=>setDatos(d=>({...d, contenidoPractica:d.contenidoPractica.filter((_,idx)=>idx!==i)}))}>Eliminar</button>
-                    </div>
-                  ))}
-                  <button type="button" className="btn btn-outline-primary" onClick={addPractica}>Añadir punto</button>
-                </div>
-              </div>
-            </div>
-
-            <div className="form-text mt-2">
-              Selecciona la formación realizada. Se añadirán sus “Parte teórica” y “Parte práctica” al borrador. Si falta algún punto, añádelo.
-            </div>
-          </div></div>
-        </div>
-      )}
-
-      {/* ===== VALORACIÓN ===== */}
-      <div>
-        <h2 className="h5">Valoración</h2>
-        <div className="card"><div className="card-body">
           <div className="row g-3">
             <div className="col-md-4">
               <div className="input-group">
@@ -530,7 +633,8 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
             </div>
           </div>
         </div></div>
-      </div>
+        </div>
+      )}
 
       <div className="d-flex justify-content-between">
         <button type="button" className="btn btn-secondary" onClick={onChooseAnother}>Elegir otro informe</button>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -23,7 +23,7 @@ export default function Home({ onSelect }) {
       <div className="d-grid gap-2">
         <button className="btn btn-primary" onClick={() => onSelect('formacion')}>Informe de Formación</button>
         <button className="btn btn-primary" onClick={() => onSelect('simulacro')}>Informe de Simulacro</button>
-        <button className="btn btn-primary" onClick={() => onSelect('preventivo')}>Informe de Preventivo</button>
+        <button className="btn btn-primary" onClick={() => onSelect('preventivo')}>Informe de Preventivos</button>
       </div>
     </div>
   )

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -45,6 +45,12 @@ const preventivoCardLabels = {
   EN: { registro: 'Logbook', bombero: 'Firefighter', fecha: 'Exercise date' },
 }
 
+const signatureTexts = {
+  ES: { closing: 'Atentamente,', signature: 'Jaime Martret. Responsable de formaciones' },
+  CA: { closing: 'Atentament,', signature: 'Jaime Martret. Responsable de formacions' },
+  EN: { closing: 'Sincerely,', signature: 'Jaime Martret. Head of Training' },
+}
+
 const normalizeText = (value = '') =>
   value
     .normalize('NFD')
@@ -172,6 +178,7 @@ export default function Preview(props) {
   const idiomaLabel = idioma === 'CA' ? 'Català' : idioma === 'EN' ? 'English' : 'Castellano'
   const preventivoLabels = preventivoHeadings[idioma] || preventivoHeadings.ES
   const preventivoCard = preventivoCardLabels[idioma] || preventivoCardLabels.ES
+  const signatureText = signatureTexts[idioma] || signatureTexts.ES
 
   const [aiHtml, setAiHtml] = useState(null)
   const [aiBusy, setAiBusy] = useState(false)
@@ -412,21 +419,21 @@ export default function Preview(props) {
             <>
               <hr className="my-4" />
               <div className="d-grid gap-3">
-                <div className="border rounded p-3 bg-light">
+                <div>
                   <h5 className="card-title mb-2">{preventivoLabels.trabajos}</h5>
-                  <p className="mb-0" style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.trabajos || '—'}</p>
+                  <p style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.trabajos || '—'}</p>
                 </div>
-                <div className="border rounded p-3 bg-light">
+                <div>
                   <h5 className="card-title mb-2">{preventivoLabels.tareas}</h5>
-                  <p className="mb-0" style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.tareas || '—'}</p>
+                  <p style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.tareas || '—'}</p>
                 </div>
-                <div className="border rounded p-3 bg-light">
+                <div>
                   <h5 className="card-title mb-2">{preventivoLabels.observaciones}</h5>
-                  <p className="mb-0" style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.observaciones || '—'}</p>
+                  <p style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.observaciones || '—'}</p>
                 </div>
-                <div className="border rounded p-3 bg-light">
+                <div>
                   <h5 className="card-title mb-2">{preventivoLabels.incidencias}</h5>
-                  <p className="mb-0" style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.incidencias || '—'}</p>
+                  <p style={{ whiteSpace: 'pre-wrap' }}>{datos?.preventivo?.incidencias || '—'}</p>
                 </div>
               </div>
             </>
@@ -482,9 +489,8 @@ export default function Preview(props) {
 
           <hr className="my-4" />
           <div>
-            <p className="mb-1">Atentamente,</p>
-            <strong>Jaime Martret</strong>
-            <div className="text-danger">Responsable de formaciones</div>
+            <p className="mb-1">{signatureText.closing}</p>
+            <p className="mb-0 fw-bold">{signatureText.signature}</p>
           </div>
 
           {Array.isArray(imagenes) && imagenes.length > 0 && (

--- a/src/pdf/reportPdfmake.js
+++ b/src/pdf/reportPdfmake.js
@@ -114,6 +114,126 @@ const stripHtml = (html) =>
     .replace(/&nbsp;/g, ' ')
     .trim()
 
+const footerSimulacro = () => ({
+  margin: [58, 0, 58, 18],
+  stack: [
+    {
+      table: {
+        widths: ['*', '*', '*'],
+        body: [
+          [
+            {
+              stack: [
+                { text: 'BARCELONA', color: '#E1062C', bold: true, fontSize: 9 },
+                { text: 'C. Moratín, 100 · 08206 Sabadell · Barcelona', fontSize: 8 },
+                { text: 'Tel. +34 935 604 636', fontSize: 8 },
+              ],
+            },
+            {
+              stack: [
+                { text: 'MADRID', color: '#E1062C', bold: true, fontSize: 9 },
+                { text: 'C. Primavera, 1 · 28500 Arganda del Rey · Madrid', fontSize: 8 },
+                { text: 'Tel. +34 918 283 898', fontSize: 8 },
+              ],
+            },
+            {
+              stack: [
+                { text: 'CÁDIZ', color: '#E1062C', bold: true, fontSize: 9 },
+                { text: 'C. Hungría, 11 Nave 1B · 11011 Cádiz', fontSize: 8 },
+                { text: ' ', fontSize: 8 },
+              ],
+            },
+          ],
+        ],
+      },
+      columnGap: 18,
+      layout: {
+        hLineWidth: () => 0,
+        vLineWidth: () => 0,
+        paddingLeft: () => 8,
+        paddingRight: () => 8,
+        paddingTop: () => 6,
+        paddingBottom: () => 6,
+        fillColor: () => '#F5F5F5',
+      },
+    },
+    {
+      text: 'www.gepservices.es',
+      alignment: 'right',
+      color: '#E1062C',
+      bold: true,
+      margin: [0, 6, 0, 0],
+      fontSize: 9,
+    },
+  ],
+})
+
+const preventivoPdfLabels = {
+  ES: {
+    titulo: 'INFORME PREVENTIVO',
+    fecha: 'Fecha del ejercicio',
+    generales: 'Datos generales',
+    registro: 'Registro',
+    trabajos: 'Trabajos',
+    tareas: 'Tareas',
+    observaciones: 'Observaciones',
+    incidencias: 'Incidencias',
+    firma: 'Firma',
+    anexos: 'Anexo de imágenes',
+    bombero: 'Bombero/a',
+    idioma: 'Idioma',
+    presupuesto: 'Nº Presupuesto',
+    cliente: 'Cliente',
+    cif: 'CIF',
+    direccionFiscal: 'Dirección fiscal',
+    direccionSimulacro: 'Dirección del simulacro',
+    contacto: 'Persona de contacto',
+    comercial: 'Comercial',
+  },
+  CA: {
+    titulo: 'INFORME PREVENTIU',
+    fecha: "Data de l'exercici",
+    generales: 'Dades generals',
+    registro: 'Registre',
+    trabajos: 'Treballs',
+    tareas: 'Tasques',
+    observaciones: 'Observacions',
+    incidencias: 'Incidències',
+    firma: 'Signatura',
+    anexos: "Annex d'imatges",
+    bombero: 'Bomber/a',
+    idioma: 'Idioma',
+    presupuesto: 'Núm. de pressupost',
+    cliente: 'Client',
+    cif: 'NIF/CIF',
+    direccionFiscal: 'Adreça fiscal',
+    direccionSimulacro: 'Adreça del simulacre',
+    contacto: 'Persona de contacte',
+    comercial: 'Comercial',
+  },
+  EN: {
+    titulo: 'PREVENTIVE REPORT',
+    fecha: 'Exercise date',
+    generales: 'General information',
+    registro: 'Logbook',
+    trabajos: 'Works performed',
+    tareas: 'Tasks',
+    observaciones: 'Observations',
+    incidencias: 'Incidents',
+    firma: 'Signature',
+    anexos: 'Image annex',
+    bombero: 'Firefighter',
+    idioma: 'Language',
+    presupuesto: 'Budget ID',
+    cliente: 'Customer',
+    cif: 'Tax ID',
+    direccionFiscal: 'Fiscal address',
+    direccionSimulacro: 'Drill address',
+    contacto: 'Contact person',
+    comercial: 'Account manager',
+  },
+}
+
 // ---------- docDefinition ----------
 const buildDocDefinition = ({
   dealId,
@@ -141,60 +261,6 @@ const buildDocDefinition = ({
   }))
 
   if (datos?.tipo === 'simulacro') {
-    const footerSimulacro = () => ({
-      margin: [58, 0, 58, 18],
-      stack: [
-        {
-          table: {
-            widths: ['*', '*', '*'],
-            body: [
-              [
-                {
-                  stack: [
-                    { text: 'BARCELONA', color: '#E1062C', bold: true, fontSize: 9 },
-                    { text: 'C. Moratín, 100 · 08206 Sabadell · Barcelona', fontSize: 8 },
-                    { text: 'Tel. +34 935 604 636', fontSize: 8 },
-                  ],
-                },
-                {
-                  stack: [
-                    { text: 'MADRID', color: '#E1062C', bold: true, fontSize: 9 },
-                    { text: 'C. Primavera, 1 · 28500 Arganda del Rey · Madrid', fontSize: 8 },
-                    { text: 'Tel. +34 918 283 898', fontSize: 8 },
-                  ],
-                },
-                {
-                  stack: [
-                    { text: 'CÁDIZ', color: '#E1062C', bold: true, fontSize: 9 },
-                    { text: 'C. Hungría, 11 Nave 1B · 11011 Cádiz', fontSize: 8 },
-                    { text: ' ', fontSize: 8 },
-                  ],
-                },
-              ],
-            ],
-          },
-          columnGap: 18,
-          layout: {
-            hLineWidth: () => 0,
-            vLineWidth: () => 0,
-            paddingLeft: () => 8,
-            paddingRight: () => 8,
-            paddingTop: () => 6,
-            paddingBottom: () => 6,
-            fillColor: () => '#F5F5F5',
-          },
-        },
-        {
-          text: 'www.gepservices.es',
-          alignment: 'right',
-          color: '#E1062C',
-          bold: true,
-          margin: [0, 6, 0, 0],
-          fontSize: 9,
-        },
-      ],
-    });
-
     return {
       pageSize: 'A4',
       pageMargins: [58,110,58,90],
@@ -280,6 +346,99 @@ const buildDocDefinition = ({
         ...(Array.isArray(imagenes) && imagenes.length
           ? [
               { text:'Anexos — Imágenes de apoyo', style:'h2', color:'#000', margin:[0,18,0,6], pageBreak:'before' },
+              ...imageRows,
+            ]
+          : []),
+      ],
+    }
+  }
+
+  if (datos?.tipo === 'preventivo') {
+    const idioma = (datos?.idioma || formador?.idioma || 'ES').toUpperCase()
+    const labels = preventivoPdfLabels[idioma] || preventivoPdfLabels.ES
+    const idiomaTexto = idioma === 'CA' ? 'Català' : idioma === 'EN' ? 'English' : 'Castellano'
+    const prev = datos?.preventivo || {}
+
+    return {
+      pageSize: 'A4',
+      pageMargins: [58,110,58,90],
+      defaultStyle: { fontSize:10, lineHeight:1.25, font:'Poppins' },
+      styles: {
+        h1: { fontSize:16, bold:true, margin:[0,0,0,6] },
+        h2: { fontSize:13, bold:true, margin:[0,14,0,6], color:'#E1062C' },
+        h3: { fontSize:11, bold:true, margin:[0,10,0,4] },
+        h4: { fontSize:10, bold:true, margin:[0,8,0,2] },
+        small: { fontSize:9, color:'#666' },
+        caption: { fontSize:8, color:'#666' },
+        k: { bold:true },
+      },
+      header: () => ({ image: headerDataUrl, width:479, alignment:'center', margin:[0,18,0,0] }),
+      footer: footerSimulacro,
+      pageBreakBefore: (currentNode) => {
+        if (currentNode.id === 'informeTecnico') {
+          const sp = currentNode.startPosition
+          if (sp && sp.pageNumber === 1) return true
+        }
+        return false
+      },
+      content: [
+        { text: labels.titulo, style:'h1' },
+        { text: [{ text: `${labels.fecha}: `, bold:true }, { text: datos?.fecha || '—' }], margin:[0,0,0,6] },
+        {
+          table: {
+            widths: ['*'],
+            body: [[{
+              stack: [
+                { text: labels.generales, style:'h3', margin:[0,0,0,6] },
+                {
+                  columns: [
+                    {
+                      width:'50%',
+                      stack: [
+                        { columns: kv(labels.presupuesto, dealId) },
+                        { columns: kv(labels.cliente, datos?.cliente) },
+                        { columns: kv(labels.cif, datos?.cif) },
+                        { columns: kv(labels.direccionFiscal, datos?.direccionOrg) },
+                        { columns: kv(labels.direccionSimulacro, datos?.sede) },
+                        { columns: kv(labels.contacto, datos?.contacto) },
+                        { columns: kv(labels.comercial, datos?.comercial) },
+                      ],
+                    },
+                    {
+                      width:'50%',
+                      stack: [
+                        { text: labels.registro, style:'h4', margin:[0,0,0,4] },
+                        { columns: kv(labels.bombero, formador?.nombre) },
+                        { columns: kv(labels.idioma, idiomaTexto) },
+                        { columns: kv(labels.fecha, datos?.fecha) },
+                      ],
+                    },
+                  ],
+                  columnGap:20,
+                },
+              ],
+              fillColor:'#F3F3F3',
+              margin:[8,8,8,8],
+            }]],
+          },
+          layout:{ hLineWidth:()=>0, vLineWidth:()=>0, paddingTop:()=>0, paddingBottom:()=>0, paddingLeft:()=>0, paddingRight:()=>0 },
+          margin:[0,8,0,0],
+        },
+        { text: labels.trabajos, style:'h2' },
+        { text: prev.trabajos || '—', margin:[0,0,0,6] },
+        { text: labels.tareas, style:'h2' },
+        { text: prev.tareas || '—', margin:[0,0,0,6] },
+        { text: labels.observaciones, style:'h2' },
+        { text: prev.observaciones || '—', margin:[0,0,0,6] },
+        { text: labels.incidencias, style:'h2' },
+        { text: prev.incidencias || '—', margin:[0,0,0,12] },
+        ...(aiContent ? [{ id:'informeTecnico', stack:Array.isArray(aiContent)?aiContent:[aiContent] }] : []),
+        { text:'Atentamente,', margin:[0,18,0,2] },
+        { text:'Jaime Martret', style:'k' },
+        { text:'Responsable de formaciones', color:'#E1062C', margin:[0,2,0,0] },
+        ...(Array.isArray(imagenes) && imagenes.length
+          ? [
+              { text: labels.anexos, style:'h2', color:'#000', margin:[0,18,0,6], pageBreak:'before' },
               ...imageRows,
             ]
           : []),
@@ -507,7 +666,13 @@ export async function generateReportPdfmake(draft) {
 
   const fecha = (datos?.fecha || '').slice(0, 10)
   const cliente = (datos?.cliente || '').replace(/[^\w\s\-._]/g, '').trim() || 'Cliente'
-  const titulo = (datos?.formacionTitulo || 'Formación').replace(/[^\w\s\-._]/g, '').trim()
+  const rawTipo = datos?.tipo || type
+  const baseTitulo = rawTipo === 'preventivo'
+    ? 'Preventivo'
+    : rawTipo === 'simulacro'
+      ? 'Simulacro'
+      : (datos?.formacionTitulo || 'Formación')
+  const titulo = baseTitulo.replace(/[^\w\s\-._]/g, '').trim()
   const nombre = `GEP Group – ${dealId || 'SinPresu'} – ${cliente} – ${titulo} – ${fecha || 'fecha'}.pdf`
 
   pdfMake.createPdf(docDefinition).download(nombre)


### PR DESCRIPTION
## Summary
- reshape the preventivo form so its dedicated sections use large editors and the attachment block mirrors the annex requirement
- refresh the preventivo preview and PDF layout to highlight the four report sections and keep contact data under cliente
- update the preventivo AI system and prompt so the assistant writes as the private firefighter team with 350–450 word sections

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c995970920832893eaa207e97b9f83