### PR TITLE
Añadir botón superior para elegir otro informe

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -396,6 +396,12 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
         </div>
       </div>
 
+      <div className="d-flex justify-content-end mb-2">
+        <button type="button" className="btn btn-secondary" onClick={onChooseAnother}>
+          Elegir otro informe
+        </button>
+      </div>
+
       {/* ===== Cliente + Formador en 2 columnas ===== */}
       <div className="row g-3 align-items-stretch">
         {/* DATOS DEL CLIENTE */}


### PR DESCRIPTION
## Resumen
- agregar un botón adicional de "Elegir otro informe" debajo del encabezado del formulario
- reutilizar la acción existente para salir al listado desde cualquier tipo de informe

## Pruebas
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7dea22408328be48c171b990de9f