### PR TITLE
Protect Netlify functions with shared secret

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,9 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  REPORTS_API_TOKEN = ""
+  VITE_REPORTS_API_TOKEN = ""
+  REPORTS_ALLOWED_ORIGIN = "https://www.gepservices.es"
 
 [[redirects]]
   from = "/*"

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -4,6 +4,19 @@ import plantillasBase from '../utils/plantillas.json'
 import logoImg from '../assets/logo-nuevo.png'
 import { triesKey, htmlKey } from '../utils/keys'
 
+let warnedMissingReportsToken = false
+const getReportsAuthHeaders = () => {
+  const token = import.meta.env.VITE_REPORTS_API_TOKEN
+  if (!token) {
+    if (!warnedMissingReportsToken) {
+      console.warn('VITE_REPORTS_API_TOKEN no está configurado; las peticiones a Netlify serán rechazadas.')
+      warnedMissingReportsToken = true
+    }
+    return {}
+  }
+  return { Authorization: `Bearer ${token}` }
+}
+
 const fileToDataURL = (file) =>
   new Promise((res, rej) => {
     const reader = new FileReader()
@@ -91,7 +104,8 @@ export default function Form({ initial, onNext, title = 'Informe de Formación',
     setLoadingDeal(true)
     try {
       const r = await fetch('/.netlify/functions/getDeal', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...getReportsAuthHeaders() },
         body: JSON.stringify({ dealId }),
       })
       const data = await r.json()

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -4,6 +4,19 @@ import logoImg from '../assets/logo-nuevo.png'
 import { generateReportPdfmake } from '../pdf/reportPdfmake'
 import { triesKey, htmlKey } from '../utils/keys'
 
+let warnedMissingReportsToken = false
+const getReportsAuthHeaders = () => {
+  const token = import.meta.env.VITE_REPORTS_API_TOKEN
+  if (!token) {
+    if (!warnedMissingReportsToken) {
+      console.warn('VITE_REPORTS_API_TOKEN no está configurado; las peticiones a Netlify serán rechazadas.')
+      warnedMissingReportsToken = true
+    }
+    return {}
+  }
+  return { Authorization: `Bearer ${token}` }
+}
+
 const maxTries = 3
 
 const preventivoHeadings = {
@@ -268,7 +281,7 @@ export default function Preview(props) {
     try {
       const r = await fetch('/.netlify/functions/generateReport', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getReportsAuthHeaders() },
         body: JSON.stringify({ formador, datos }),
       })
       const raw = await r.text()


### PR DESCRIPTION
## Summary
- require the REPORTS_API_TOKEN shared secret on the Netlify functions and tighten their CORS configuration
- send the Authorization header from the form and preview fetch calls so requests include the shared secret
- document the new Netlify environment variables for the shared token and allowed origin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca86230a688328b91e4dbf7e767617