### PR TITLE
Add token-based authentication with login gate

### DIFF
--- a/netlify/manual-despliegue.md
+++ b/netlify/manual-despliegue.md
@@ -1,0 +1,29 @@
+# Manual de despliegue
+
+## Configuración de autenticación por token
+
+La aplicación utiliza un flujo de autenticación basado en tokens corporativos. Las credenciales válidas se definen mediante una variable de entorno que Netlify inyecta en el build (`VITE_AUTHORIZED_USERS`). Cada par `correo:token` habilita el acceso a una persona usuaria.
+
+### Alta o edición de usuarios autorizados
+
+1. Accede a Netlify y selecciona el sitio correspondiente.
+2. Entra en **Site settings → Build & deploy → Environment → Environment variables**.
+3. Crea o edita la variable `VITE_AUTHORIZED_USERS` con el formato:
+
+   ```text
+   persona1@empresa.com:token-seguro-1,persona2@empresa.com:token-seguro-2
+   ```
+
+   - Se admiten comas, punto y coma o saltos de línea como separadores entre credenciales.
+   - Los correos no distinguen mayúsculas/minúsculas, pero los tokens sí.
+4. Guarda los cambios y despliega nuevamente el sitio para que Vite recompile con los nuevos valores. Un _trigger_ manual de deploy desde **Deploys → Trigger deploy → Deploy site** es suficiente.
+5. Comunica el token asignado a cada persona por un canal seguro.
+
+### Revocación de tokens
+
+1. Sigue los pasos anteriores hasta el paso 2.
+2. Elimina el par `correo:token` correspondiente o reemplaza el token por uno nuevo.
+3. Guarda la variable y vuelve a desplegar la aplicación para invalidar sesiones futuras. El cierre de sesión es inmediato porque los tokens ya no coincidirán con el valor almacenado en Netlify.
+4. Si necesitas cerrar sesiones activas, solicita a la persona usuaria que pulse **Cerrar sesión** o elimina manualmente los datos de sesión desde las herramientas del navegador.
+
+> **Nota:** Netlify oculta el valor de la variable tras guardarla. Para rotar un token, vuelve a introducir toda la lista de credenciales y asegúrate de almacenarla en un gestor seguro.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,80 +1,159 @@
 // src/App.jsx
-import React, { useState } from "react";
+import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
 import Form from "./components/Form";
 import Preview from "./components/Preview";
 import Home from "./components/Home";
+import Login from "./components/Login";
+
+export const AuthContext = createContext({
+  isAuthenticated: false,
+  user: null,
+  login: () => {},
+  logout: () => {},
+});
+
+const AUTH_STORAGE_KEY = "gep-informes-auth";
 
 export default function App() {
+  const [authState, setAuthState] = useState(() => {
+    if (typeof window !== "undefined") {
+      const stored = window.sessionStorage.getItem(AUTH_STORAGE_KEY);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          if (parsed && typeof parsed === "object") {
+            return {
+              isAuthenticated: Boolean(parsed.isAuthenticated),
+              user: parsed.user || null,
+            };
+          }
+        } catch (error) {
+          console.warn("No se pudo recuperar el estado de autenticación almacenado", error);
+        }
+      }
+    }
+    return { isAuthenticated: false, user: null };
+  });
   const [screen, setScreen] = useState('home');
   const [formacion, setFormacion] = useState(null);
   const [simulacro, setSimulacro] = useState(null);
   const [preventivo, setPreventivo] = useState(null);
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      if (authState.isAuthenticated) {
+        window.sessionStorage.setItem(
+          AUTH_STORAGE_KEY,
+          JSON.stringify({
+            isAuthenticated: authState.isAuthenticated,
+            user: authState.user,
+          }),
+        );
+      } else {
+        window.sessionStorage.removeItem(AUTH_STORAGE_KEY);
+      }
+    }
+  }, [authState]);
+
+  const login = useCallback((userData) => {
+    setAuthState({ isAuthenticated: true, user: userData });
+  }, []);
+
+  const logout = useCallback(() => {
+    setAuthState({ isAuthenticated: false, user: null });
+    setScreen('home');
+    setFormacion(null);
+    setSimulacro(null);
+    setPreventivo(null);
+  }, []);
+
+  const authValue = useMemo(() => ({
+    ...authState,
+    login,
+    logout,
+  }), [authState, login, logout]);
+
   return (
-    <div className="container py-4">
-      {screen === 'home' && (
-        <Home onSelect={(tipo) => setScreen(`${tipo}-form`)} />
-      )}
-      {screen === 'formacion-form' && (
-        <Form
-          initial={formacion}
-          title="Informe de Formación"
-          type="formacion"
-          onChooseAnother={() => setScreen('home')}
-          onNext={(data) => {
-            setFormacion(data);
-            setScreen('formacion-preview');
-          }}
-        />
-      )}
-      {screen === 'formacion-preview' && (
-        <Preview
-          data={formacion}
-          title="Informe de Formación"
-          type="formacion"
-          onBack={() => setScreen('formacion-form')}
-        />
-      )}
-      {screen === 'simulacro-form' && (
-        <Form
-          initial={simulacro}
-          title="Informe de Simulacro"
-          type="simulacro"
-          onChooseAnother={() => setScreen('home')}
-          onNext={(data) => {
-            setSimulacro(data);
-            setScreen('simulacro-preview');
-          }}
-        />
-      )}
-      {screen === 'simulacro-preview' && (
-        <Preview
-          data={simulacro}
-          title="Informe de Simulacro"
-          type="simulacro"
-          onBack={() => setScreen('simulacro-form')}
-        />
-      )}
-      {screen === 'preventivo-form' && (
-        <Form
-          initial={preventivo}
-          title="Informe de Preventivos"
-          type="preventivo"
-          onChooseAnother={() => setScreen('home')}
-          onNext={(data) => {
-            setPreventivo(data);
-            setScreen('preventivo-preview');
-          }}
-        />
-      )}
-      {screen === 'preventivo-preview' && (
-        <Preview
-          data={preventivo}
-          title="Informe de Preventivos"
-          type="preventivo"
-          onBack={() => setScreen('preventivo-form')}
-        />
-      )}
-    </div>
+    <AuthContext.Provider value={authValue}>
+      <div className="container py-4">
+        {authState.isAuthenticated ? (
+          <>
+            <div className="d-flex justify-content-end align-items-center gap-3 mb-4">
+              <small className="text-muted mb-0">
+                Sesión iniciada como <strong>{authState.user?.email}</strong>
+              </small>
+              <button type="button" className="btn btn-outline-secondary btn-sm" onClick={logout}>
+                Cerrar sesión
+              </button>
+            </div>
+            {screen === 'home' && (
+              <Home onSelect={(tipo) => setScreen(`${tipo}-form`)} />
+            )}
+            {screen === 'formacion-form' && (
+              <Form
+                initial={formacion}
+                title="Informe de Formación"
+                type="formacion"
+                onChooseAnother={() => setScreen('home')}
+                onNext={(data) => {
+                  setFormacion(data);
+                  setScreen('formacion-preview');
+                }}
+              />
+            )}
+            {screen === 'formacion-preview' && (
+              <Preview
+                data={formacion}
+                title="Informe de Formación"
+                type="formacion"
+                onBack={() => setScreen('formacion-form')}
+              />
+            )}
+            {screen === 'simulacro-form' && (
+              <Form
+                initial={simulacro}
+                title="Informe de Simulacro"
+                type="simulacro"
+                onChooseAnother={() => setScreen('home')}
+                onNext={(data) => {
+                  setSimulacro(data);
+                  setScreen('simulacro-preview');
+                }}
+              />
+            )}
+            {screen === 'simulacro-preview' && (
+              <Preview
+                data={simulacro}
+                title="Informe de Simulacro"
+                type="simulacro"
+                onBack={() => setScreen('simulacro-form')}
+              />
+            )}
+            {screen === 'preventivo-form' && (
+              <Form
+                initial={preventivo}
+                title="Informe de Preventivos"
+                type="preventivo"
+                onChooseAnother={() => setScreen('home')}
+                onNext={(data) => {
+                  setPreventivo(data);
+                  setScreen('preventivo-preview');
+                }}
+              />
+            )}
+            {screen === 'preventivo-preview' && (
+              <Preview
+                data={preventivo}
+                title="Informe de Preventivos"
+                type="preventivo"
+                onBack={() => setScreen('preventivo-form')}
+              />
+            )}
+          </>
+        ) : (
+          <Login />
+        )}
+      </div>
+    </AuthContext.Provider>
   );
 }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,125 @@
+import React, { useContext, useMemo, useState } from "react";
+import { AuthContext } from "../App";
+
+const parseCredentials = (rawValue) => {
+  if (!rawValue || typeof rawValue !== "string") {
+    return {};
+  }
+
+  return rawValue
+    .split(/[,\n;]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .reduce((accumulator, entry) => {
+      const separatorIndex = entry.indexOf(":");
+      if (separatorIndex === -1) {
+        return accumulator;
+      }
+
+      const email = entry.slice(0, separatorIndex).trim().toLowerCase();
+      const token = entry.slice(separatorIndex + 1).trim();
+
+      if (email && token) {
+        accumulator[email] = token;
+      }
+
+      return accumulator;
+    }, {});
+};
+
+export default function Login() {
+  const { login } = useContext(AuthContext);
+  const [email, setEmail] = useState("");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+
+  const credentials = useMemo(
+    () => parseCredentials(import.meta.env.VITE_AUTHORIZED_USERS),
+    [],
+  );
+
+  const isConfigured = Object.keys(credentials).length > 0;
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    setError("");
+
+    const normalizedEmail = email.trim().toLowerCase();
+    const normalizedToken = token.trim();
+
+    if (!normalizedEmail || !normalizedToken) {
+      setError("Introduce tu correo corporativo y token de acceso.");
+      return;
+    }
+
+    const storedToken = credentials[normalizedEmail];
+
+    if (storedToken && storedToken === normalizedToken) {
+      login({ email: normalizedEmail });
+      setEmail("");
+      setToken("");
+      return;
+    }
+
+    setError("Credenciales no válidas. Revisa la información proporcionada.");
+  };
+
+  return (
+    <div className="d-flex flex-column align-items-center py-5">
+      <div className="card shadow-sm w-100" style={{ maxWidth: 420 }}>
+        <div className="card-body">
+          <h1 className="h4 mb-3 text-center">Accede a los informes</h1>
+          <p className="text-muted small text-center mb-4">
+            Introduce tu correo corporativo y el token facilitado por el área de Sistemas.
+          </p>
+          {error && (
+            <div className="alert alert-danger" role="alert">
+              {error}
+            </div>
+          )}
+          {!isConfigured && (
+            <div className="alert alert-warning" role="alert">
+              No hay credenciales configuradas en el entorno. Contacta con la persona administradora.
+            </div>
+          )}
+          <form className="d-grid gap-3" onSubmit={handleSubmit}>
+            <div className="d-grid gap-2">
+              <label className="form-label" htmlFor="login-email">
+                Correo corporativo
+              </label>
+              <input
+                id="login-email"
+                type="email"
+                className="form-control"
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+            <div className="d-grid gap-2">
+              <label className="form-label" htmlFor="login-token">
+                Token de acceso
+              </label>
+              <input
+                id="login-token"
+                type="password"
+                className="form-control"
+                autoComplete="current-password"
+                value={token}
+                onChange={(event) => setToken(event.target.value)}
+                required
+              />
+              <div className="form-text">
+                El token distingue mayúsculas y minúsculas. No lo compartas públicamente.
+              </div>
+            </div>
+            <button className="btn btn-primary" type="submit" disabled={!isConfigured}>
+              Iniciar sesión
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the application screens with an authentication context that persists session data and exposes login/logout helpers
- add a token-based login screen that validates user credentials using the VITE_AUTHORIZED_USERS environment variable
- document how to configure and revoke Netlify environment variables for authentication tokens in the deployment manual

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca862017988328ab65162e573b6f33