### PR TITLE
Habilitar autofill de Chrome

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -131,16 +131,21 @@ export default function Login() {
               No hay credenciales configuradas en el entorno. Si necesitas acceso, ponte en contacto con Jaime.
             </div>
           )}
-          <form className="d-grid gap-3" onSubmit={handleSubmit}>
+          <form
+            className="d-grid gap-3"
+            onSubmit={handleSubmit}
+            autoComplete="on"
+          >
             <div className="d-grid gap-2">
               <label className="form-label" htmlFor="login-email">
                 Correo
               </label>
               <input
                 id="login-email"
+                name="email"
                 type="email"
                 className="form-control"
-                autoComplete="email"
+                autoComplete="username"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
                 required
@@ -153,6 +158,7 @@ export default function Login() {
               <div className="input-group">
                 <input
                   id="login-token"
+                  name="password"
                   type={isTokenVisible ? "text" : "password"}
                   className="form-control"
                   autoComplete="current-password"


### PR DESCRIPTION
## Summary
- permitir que el formulario de inicio de sesión sea compatible con la autocompletación de gestores de contraseñas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab08e244c83289972c2367edaa81f