### PR TITLE
Add email delivery function and UI

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,7 @@
   REPORTS_API_TOKEN = ""
   VITE_REPORTS_API_TOKEN = ""
   REPORTS_ALLOWED_ORIGIN = "https://www.gepservices.es"
+  RESEND_API_KEY = ""
 
 [[redirects]]
   from = "/*"

--- a/netlify/functions/sendReportEmail.js
+++ b/netlify/functions/sendReportEmail.js
@@ -1,0 +1,207 @@
+// netlify/functions/sendReportEmail.js
+const ALLOWED_ORIGIN = process.env.REPORTS_ALLOWED_ORIGIN || 'https://www.gepservices.es';
+
+const cors = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Headers': 'authorization,content-type',
+  'Access-Control-Expose-Headers': 'content-type',
+};
+
+const ensureString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const splitAddresses = (value) => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => ensureString(item))
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[,;\n]/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const extractBase64 = (attachment, index) => {
+  if (!attachment) throw new Error(`attachments[${index}] no contiene datos`);
+
+  const fromObj = (field) => {
+    const value = attachment[field];
+    return typeof value === 'string' ? value.trim() : '';
+  };
+
+  let raw = '';
+  if (typeof attachment === 'string') {
+    raw = attachment.trim();
+  } else {
+    raw =
+      fromObj('content') ||
+      fromObj('data') ||
+      fromObj('dataUrl') ||
+      fromObj('blob') ||
+      fromObj('base64');
+  }
+
+  if (!raw) throw new Error(`attachments[${index}] carece de contenido en base64`);
+
+  const trimmed = raw.trim();
+  const cleaned = trimmed.startsWith('data:')
+    ? trimmed.slice(trimmed.indexOf(',') + 1).trim()
+    : trimmed;
+
+  if (!cleaned) throw new Error(`attachments[${index}] contiene un base64 vacío`);
+
+  try {
+    const buffer = Buffer.from(cleaned, 'base64');
+    if (!buffer || buffer.length === 0) throw new Error('Contenido vacío');
+    return buffer.toString('base64');
+  } catch (error) {
+    throw new Error(`attachments[${index}] no es un base64 válido`);
+  }
+};
+
+const normaliseAttachments = (attachments) => {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    throw new Error('attachments debe ser un array con al menos un elemento');
+  }
+
+  return attachments.map((item, index) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error(`attachments[${index}] debe ser un objeto`);
+    }
+
+    const filename = ensureString(item.filename || item.name);
+    if (!filename) throw new Error(`attachments[${index}] necesita filename`);
+
+    const contentType = ensureString(item.contentType || item.type) || 'application/pdf';
+    const content = extractBase64(item, index);
+
+    return {
+      filename,
+      content,
+      contentType,
+    };
+  });
+};
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors };
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const sharedSecret = process.env.REPORTS_API_TOKEN;
+  if (!sharedSecret) {
+    console.error('[sendReportEmail] Missing REPORTS_API_TOKEN');
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Server misconfiguration' }),
+    };
+  }
+
+  const authHeader = event.headers?.authorization || event.headers?.Authorization || '';
+  const expectedHeader = `Bearer ${sharedSecret}`;
+  if (authHeader !== expectedHeader) {
+    return {
+      statusCode: 401,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    };
+  }
+
+  const RESEND_API_KEY = process.env.RESEND_API_KEY;
+  if (!RESEND_API_KEY) {
+    console.error('[sendReportEmail] Missing RESEND_API_KEY');
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Email service misconfiguration' }),
+    };
+  }
+
+  let data = null;
+  try {
+    data = JSON.parse(event.body || '{}');
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Invalid JSON body' }),
+    };
+  }
+
+  try {
+    const from = ensureString(data.from);
+    if (!from) throw new Error('from es obligatorio');
+
+    const to = splitAddresses(data.to);
+    if (!to.length) throw new Error('to debe incluir al menos un destinatario');
+
+    const cc = splitAddresses(data.cc);
+    const subject = ensureString(data.subject);
+    if (!subject) throw new Error('subject es obligatorio');
+
+    const text = ensureString(data.text);
+    if (!text) throw new Error('text es obligatorio');
+
+    const attachments = normaliseAttachments(data.attachments);
+
+    const body = {
+      from,
+      to,
+      subject,
+      text,
+      attachments: attachments.map((att) => ({
+        filename: att.filename,
+        content: att.content,
+        contentType: att.contentType,
+      })),
+    };
+    if (cc.length) body.cc = cc;
+
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const raw = await response.text();
+    let json = null;
+    if (raw) {
+      try {
+        json = JSON.parse(raw);
+      } catch (error) {
+        console.error('[sendReportEmail] Error parsing response JSON:', error, raw);
+      }
+    }
+
+    if (!response.ok) {
+      const message = json?.error?.message || json?.message || raw || 'Email provider error';
+      throw new Error(message);
+    }
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ success: true, id: json?.id || null }),
+    };
+  } catch (error) {
+    console.error('[sendReportEmail] error:', error);
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: error.message || 'Unknown error' }),
+    };
+  }
+}

--- a/netlify/manual-despliegue.md
+++ b/netlify/manual-despliegue.md
@@ -29,3 +29,13 @@ La aplicación utiliza un flujo de autenticación basado en tokens corporativos.
 4. Si necesitas cerrar sesiones activas, solicita a la persona usuaria que pulse **Cerrar sesión** o elimina manualmente los datos de sesión desde las herramientas del navegador.
 
 > **Nota:** Netlify oculta el valor de la variable tras guardarla. Para rotar un token, vuelve a introducir toda la lista de credenciales y asegúrate de almacenarla en un gestor seguro.
+
+## Configuración del proveedor de correo
+
+El envío del informe por email se realiza desde una función serverless que delega en Resend (o el proveedor configurado). Para que Netlify pueda autenticarse es necesario declarar la variable `RESEND_API_KEY` en el sitio:
+
+1. Accede a **Site settings → Build & deploy → Environment → Environment variables**.
+2. Añade la variable `RESEND_API_KEY` con el token privado generado en Resend.
+3. Guarda los cambios y dispara un nuevo deploy para que la función `sendReportEmail` cargue la credencial.
+
+> Puedes gestionar la clave directamente en Resend (https://resend.com/). Si rotas la credencial, recuerda actualizar el valor en Netlify y volver a desplegar.

--- a/src/pdf/reportPdfmake.js
+++ b/src/pdf/reportPdfmake.js
@@ -622,8 +622,9 @@ const buildDocDefinition = ({
 }
 
 // ---------- API usada por Preview.jsx ----------
-export async function generateReportPdfmake(draft) {
+export async function generateReportPdfmake(draft, options = {}) {
   const { dealId, datos, formador, imagenes, type } = draft || {}
+  const mode = options.output || options.mode || 'download'
 
   const [pdfMake, htmlToPdfmake, headerDataUrl, footerDataUrl] = await Promise.all([
     ensurePdfMake(),
@@ -675,5 +676,20 @@ export async function generateReportPdfmake(draft) {
   const titulo = baseTitulo.replace(/[^\w\s\-._]/g, '').trim()
   const nombre = `GEP Group – ${dealId || 'SinPresu'} – ${cliente} – ${titulo} – ${fecha || 'fecha'}.pdf`
 
-  pdfMake.createPdf(docDefinition).download(nombre)
+  const instance = pdfMake.createPdf(docDefinition)
+
+  if (mode === 'base64') {
+    return new Promise((resolve, reject) => {
+      try {
+        instance.getBase64((data) => {
+          resolve({ base64: data, filename: nombre })
+        })
+      } catch (error) {
+        reject(error)
+      }
+    })
+  }
+
+  instance.download(nombre)
+  return { filename: nombre }
 }


### PR DESCRIPTION
## Summary
- add a `sendReportEmail` Netlify function that validates the shared token, checks the payload and calls Resend with the attached PDF
- declare the new `RESEND_API_KEY` environment variable and document how to configure it in Netlify
- extend the report preview to generate the PDF in base64, send it through the new function with Authorization and show a green/red status indicator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caabcf5ad48328a69bd23b9de3ddb9