### PR TITLE
Add email sending workflow after PDF generation

### DIFF
--- a/netlify/functions/sendReportEmail.js
+++ b/netlify/functions/sendReportEmail.js
@@ -1,0 +1,217 @@
+const ALLOWED_ORIGIN = process.env.REPORTS_ALLOWED_ORIGIN || 'https://www.gepservices.es'
+
+const cors = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Headers': 'authorization,content-type',
+  'Access-Control-Expose-Headers': 'content-type',
+}
+
+const parseList = (value) => {
+  if (!value) return []
+  const items = Array.isArray(value) ? value : String(value).split(/[\s,;]+/)
+  return items
+    .map((item) => String(item || '').trim())
+    .filter(Boolean)
+}
+
+const uniqueEmails = (list) => {
+  const seen = new Set()
+  const result = []
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  list.forEach((email) => {
+    const normalized = String(email || '').trim()
+    if (!normalized) return
+    if (!emailRegex.test(normalized)) return
+    const key = normalized.toLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(normalized)
+    }
+  })
+  return result
+}
+
+const stripHtml = (html) =>
+  (html || '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const resolvePdfBase64 = (pdf = {}) => {
+  if (pdf.base64 && typeof pdf.base64 === 'string') {
+    return pdf.base64.trim()
+  }
+  if (pdf.dataUrl && typeof pdf.dataUrl === 'string') {
+    const idx = pdf.dataUrl.indexOf(',')
+    return idx >= 0 ? pdf.dataUrl.slice(idx + 1).trim() : pdf.dataUrl.trim()
+  }
+  throw new Error('PDF attachment missing or invalid')
+}
+
+const buildPayload = ({
+  to,
+  cc,
+  bcc,
+  subject,
+  html,
+  text,
+  pdf,
+  metadata,
+  from,
+  replyTo,
+}) => {
+  const payload = {
+    from,
+    to,
+    subject: subject || 'Informe GEP',
+    attachments: [
+      {
+        filename: pdf.fileName || 'informe.pdf',
+        content: pdf.base64,
+        type: 'application/pdf',
+      },
+    ],
+  }
+
+  if (cc.length) payload.cc = cc
+  if (bcc.length) payload.bcc = bcc
+  if (replyTo) payload.reply_to = replyTo
+
+  if (html) payload.html = html
+  if (text) payload.text = text
+  if (!payload.html && payload.text) {
+    payload.html = payload.text.replace(/\n/g, '<br />')
+  }
+  if (!payload.text && payload.html) {
+    payload.text = stripHtml(payload.html)
+  }
+
+  const tags = []
+  if (metadata?.dealId) tags.push({ name: 'deal_id', value: String(metadata.dealId) })
+  if (metadata?.type) tags.push({ name: 'informe_tipo', value: String(metadata.type) })
+  if (metadata?.cliente) tags.push({ name: 'cliente', value: String(metadata.cliente).slice(0, 64) })
+  if (tags.length) payload.tags = tags
+
+  return payload
+}
+
+const sendViaResend = async (payload) => {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) throw new Error('RESEND_API_KEY not configured')
+  const baseUrl = (process.env.RESEND_BASE_URL || 'https://api.resend.com').replace(/\/$/, '')
+
+  const response = await fetch(`${baseUrl}/emails`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const raw = await response.text()
+  let data = null
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch (error) {
+      console.error('[sendReportEmail] Invalid JSON from Resend:', error, raw)
+      if (!response.ok) throw new Error(raw || 'Resend error')
+      throw new Error('Unexpected response from Resend')
+    }
+  }
+
+  if (!response.ok) {
+    const message = data?.message || data?.error || raw || 'Resend error'
+    const error = new Error(message)
+    error.statusCode = response.status
+    throw error
+  }
+
+  return data
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: cors, body: 'Method Not Allowed' }
+  }
+
+  const sharedSecret = process.env.REPORTS_API_TOKEN
+  if (!sharedSecret) {
+    console.error('[sendReportEmail] Missing REPORTS_API_TOKEN')
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Server misconfiguration' }),
+    }
+  }
+
+  const authHeader = event.headers?.authorization || event.headers?.Authorization || ''
+  if (authHeader !== `Bearer ${sharedSecret}`) {
+    return {
+      statusCode: 401,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    }
+  }
+
+  try {
+    const body = event.body ? JSON.parse(event.body) : {}
+    const toList = uniqueEmails(parseList(body.to))
+    const ccList = uniqueEmails(parseList(body.cc))
+    const bccList = uniqueEmails(parseList(body.bcc))
+
+    if (!toList.length) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json', ...cors },
+        body: JSON.stringify({ error: 'Destinatarios no válidos' }),
+      }
+    }
+
+    const pdfBase64 = resolvePdfBase64(body.pdf)
+
+    const from = process.env.REPORTS_EMAIL_FROM || process.env.RESEND_FROM || 'informes@gepservices.es'
+    const replyTo = body.replyTo || process.env.REPORTS_EMAIL_REPLY_TO || ''
+
+    const textMessage = typeof body.message === 'string' ? body.message : ''
+    const htmlMessage = typeof body.html === 'string' ? body.html : ''
+
+    const payload = buildPayload({
+      to: toList,
+      cc: ccList,
+      bcc: bccList,
+      subject: typeof body.subject === 'string' ? body.subject : 'Informe GEP',
+      html: htmlMessage || null,
+      text: textMessage || null,
+      pdf: { base64: pdfBase64, fileName: body.pdf?.fileName || 'informe.pdf' },
+      metadata: {
+        dealId: body.dealId || null,
+        type: body.type || null,
+        cliente: body.datos?.cliente || null,
+      },
+      from,
+      replyTo,
+    })
+
+    const data = await sendViaResend(payload)
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ id: data?.id || null, status: 'sent' }),
+    }
+  } catch (error) {
+    const statusCode = error.statusCode || 500
+    console.error('[sendReportEmail] error:', error)
+    return {
+      statusCode,
+      headers: { 'Content-Type': 'application/json', ...cors },
+      body: JSON.stringify({ error: error.message || 'Unexpected error' }),
+    }
+  }
+}

--- a/src/components/SendEmailModal.jsx
+++ b/src/components/SendEmailModal.jsx
@@ -1,0 +1,345 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+let warnedMissingReportsToken = false
+const getReportsAuthHeaders = () => {
+  const token = import.meta.env.VITE_REPORTS_API_TOKEN
+  if (!token) {
+    if (!warnedMissingReportsToken) {
+      console.warn('VITE_REPORTS_API_TOKEN no está configurado; las peticiones a Netlify serán rechazadas.')
+      warnedMissingReportsToken = true
+    }
+    return {}
+  }
+  return { Authorization: `Bearer ${token}` }
+}
+
+const collectEmails = (value) => {
+  if (!value) return { valid: [], invalid: [] }
+  const items = Array.isArray(value)
+    ? value
+    : String(value)
+        .split(/[\s,;]+/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+
+  const valid = []
+  const invalid = []
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  items.forEach((item) => {
+    if (emailRegex.test(item)) {
+      if (!valid.includes(item)) valid.push(item)
+    } else if (!invalid.includes(item)) {
+      invalid.push(item)
+    }
+  })
+
+  return { valid, invalid }
+}
+
+const arrayBufferToBase64 = (buffer) => {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+const ensurePdfBase64 = async (pdf) => {
+  if (!pdf) throw new Error('No hay PDF para adjuntar.')
+  if (pdf.base64) return pdf.base64
+  if (pdf.dataUrl) {
+    const commaIndex = pdf.dataUrl.indexOf(',')
+    return commaIndex >= 0 ? pdf.dataUrl.slice(commaIndex + 1) : pdf.dataUrl
+  }
+  if (pdf.arrayBuffer) return arrayBufferToBase64(pdf.arrayBuffer)
+  if (pdf.blob) {
+    const buffer = await pdf.blob.arrayBuffer()
+    return arrayBufferToBase64(buffer)
+  }
+  throw new Error('No se ha podido preparar el PDF para enviarlo por correo.')
+}
+
+export default function SendEmailModal({
+  show,
+  onClose,
+  onSuccess,
+  pdf,
+  draft,
+  title,
+}) {
+  const [to, setTo] = useState('')
+  const [cc, setCc] = useState('')
+  const [bcc, setBcc] = useState('')
+  const [subject, setSubject] = useState('')
+  const [message, setMessage] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState(null)
+
+  const dealId = draft?.dealId || ''
+  const cliente = draft?.datos?.cliente || ''
+  const fecha = draft?.datos?.fecha || ''
+  const contacto = draft?.datos?.contacto || ''
+
+  const formattedDate = useMemo(() => {
+    if (!fecha) return ''
+    try {
+      const parsed = new Date(fecha)
+      if (Number.isNaN(parsed.getTime())) return fecha
+      return parsed.toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })
+    } catch (err) {
+      console.warn('No se pudo formatear la fecha del informe.', err)
+      return fecha
+    }
+  }, [fecha])
+
+  const defaultSubject = useMemo(() => {
+    const pieces = []
+    if (title) pieces.push(title)
+    if (cliente) pieces.push(cliente)
+    if (formattedDate) pieces.push(formattedDate)
+    if (!pieces.length && dealId) pieces.push(`Presupuesto ${dealId}`)
+    return pieces.join(' · ') || 'Informe GEP'
+  }, [title, cliente, formattedDate, dealId])
+
+  const defaultMessage = useMemo(() => {
+    const greeting = contacto ? `Hola ${contacto},` : 'Hola,'
+    const mainLine = dealId
+      ? `Adjuntamos el informe correspondiente al presupuesto ${dealId}.`
+      : 'Adjuntamos el informe correspondiente.'
+    const lines = [
+      greeting,
+      '',
+      mainLine,
+      'Si necesitas cualquier aclaración o modificación, indícanoslo.',
+      '',
+      'Un saludo,',
+      'GEP Group — Formación y Servicios',
+    ]
+    return lines.join('\n')
+  }, [contacto, dealId])
+
+  useEffect(() => {
+    if (show) {
+      setSubject(defaultSubject)
+      setMessage(defaultMessage)
+      setError(null)
+    }
+  }, [show, defaultSubject, defaultMessage])
+
+  useEffect(() => {
+    if (!show) {
+      setSending(false)
+      setError(null)
+      setTo('')
+      setCc('')
+      setBcc('')
+    }
+  }, [show])
+
+  const parsedTo = useMemo(() => collectEmails(to), [to])
+  const parsedCc = useMemo(() => collectEmails(cc), [cc])
+  const parsedBcc = useMemo(() => collectEmails(bcc), [bcc])
+
+  const hasInvalidEmails =
+    parsedTo.invalid.length > 0 || parsedCc.invalid.length > 0 || parsedBcc.invalid.length > 0
+
+  const canSubmit = show && parsedTo.valid.length > 0 && !sending && !hasInvalidEmails
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!canSubmit) return
+    setSending(true)
+    setError(null)
+
+    try {
+      const base64 = await ensurePdfBase64(pdf)
+      const payload = {
+        to: parsedTo.valid,
+        cc: parsedCc.valid,
+        bcc: parsedBcc.valid,
+        subject: subject || defaultSubject,
+        message,
+        dealId,
+        type: draft?.type || draft?.datos?.tipo || null,
+        datos: {
+          cliente: draft?.datos?.cliente || null,
+          fecha: draft?.datos?.fecha || null,
+          contacto: draft?.datos?.contacto || null,
+        },
+        pdf: {
+          fileName: pdf?.fileName || 'informe.pdf',
+          base64,
+        },
+      }
+
+      const response = await fetch('/.netlify/functions/sendReportEmail', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getReportsAuthHeaders(),
+        },
+        body: JSON.stringify(payload),
+      })
+
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        const message = data?.error || data?.message || 'No se ha podido enviar el correo.'
+        throw new Error(message)
+      }
+
+      setSending(false)
+      onSuccess?.({
+        to: parsedTo.valid,
+        cc: parsedCc.valid,
+        bcc: parsedBcc.valid,
+        response: data,
+      })
+    } catch (err) {
+      console.error('Error enviando el informe por email:', err)
+      setSending(false)
+      setError(err?.message || 'No se ha podido enviar el correo.')
+    }
+  }
+
+  const attachmentSizeKb = useMemo(() => {
+    if (pdf?.blob?.size) {
+      return Math.round(pdf.blob.size / 1024)
+    }
+    if (pdf?.base64) {
+      const sizeInBytes = Math.floor((pdf.base64.length * 3) / 4)
+      return Math.round(sizeInBytes / 1024)
+    }
+    return null
+  }, [pdf])
+
+  if (!show) return null
+
+  return (
+    <>
+      <div className="modal fade show" style={{ display: 'block' }}>
+        <div className="modal-dialog modal-lg modal-dialog-scrollable">
+          <div className="modal-content">
+            <form onSubmit={handleSubmit}>
+              <div className="modal-header">
+                <h5 className="modal-title">Enviar informe por email</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  aria-label="Cerrar"
+                  onClick={onClose}
+                  disabled={sending}
+                />
+              </div>
+              <div className="modal-body">
+                <div className="mb-3">
+                  <label className="form-label">Para</label>
+                  <textarea
+                    className="form-control"
+                    rows={2}
+                    value={to}
+                    onChange={(event) => setTo(event.target.value)}
+                    placeholder="correo@empresa.com"
+                    required
+                  />
+                  <div className="form-text">
+                    Separa múltiples direcciones con comas, punto y coma o saltos de línea.
+                  </div>
+                  {parsedTo.invalid.length > 0 && (
+                    <div className="form-text text-danger">
+                      Correos no válidos: {parsedTo.invalid.join(', ')}
+                    </div>
+                  )}
+                </div>
+
+                <div className="mb-3">
+                  <label className="form-label">CC (opcional)</label>
+                  <textarea
+                    className="form-control"
+                    rows={2}
+                    value={cc}
+                    onChange={(event) => setCc(event.target.value)}
+                    placeholder="equipo@empresa.com"
+                  />
+                  {parsedCc.invalid.length > 0 && (
+                    <div className="form-text text-danger">
+                      Correos no válidos: {parsedCc.invalid.join(', ')}
+                    </div>
+                  )}
+                </div>
+
+                <div className="mb-3">
+                  <label className="form-label">CCO (opcional)</label>
+                  <textarea
+                    className="form-control"
+                    rows={2}
+                    value={bcc}
+                    onChange={(event) => setBcc(event.target.value)}
+                    placeholder="direccion@empresa.com"
+                  />
+                  {parsedBcc.invalid.length > 0 && (
+                    <div className="form-text text-danger">
+                      Correos no válidos: {parsedBcc.invalid.join(', ')}
+                    </div>
+                  )}
+                </div>
+
+                <div className="mb-3">
+                  <label className="form-label">Asunto</label>
+                  <input
+                    className="form-control"
+                    value={subject}
+                    onChange={(event) => setSubject(event.target.value)}
+                    required
+                  />
+                </div>
+
+                <div className="mb-3">
+                  <label className="form-label">Mensaje</label>
+                  <textarea
+                    className="form-control"
+                    rows={6}
+                    value={message}
+                    onChange={(event) => setMessage(event.target.value)}
+                    required
+                  />
+                  <div className="form-text">
+                    Se enviará tal cual en el cuerpo del correo.
+                  </div>
+                </div>
+
+                <div className="mb-3">
+                  <div className="alert alert-secondary mb-0" role="status">
+                    Se adjuntará el archivo <strong>{pdf?.fileName || 'informe.pdf'}</strong>
+                    {attachmentSizeKb ? ` (${attachmentSizeKb} KB aprox.)` : ''}.
+                  </div>
+                </div>
+
+                {error && (
+                  <div className="alert alert-danger" role="alert">
+                    {error}
+                  </div>
+                )}
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={onClose}
+                  disabled={sending}
+                >
+                  Cancelar
+                </button>
+                <button type="submit" className="btn btn-primary" disabled={!canSubmit}>
+                  {sending ? 'Enviando…' : 'Enviar informe'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop fade show" />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add an email action to the preview so the send button appears after generar el PDF y mostrar confirmaciones
- create a dedicated `SendEmailModal` component to recoger destinatarios, validar correos y enviar la petición firmada
- exponer la función serverless `sendReportEmail` que usa Resend para entregar el PDF adjunto con metadatos del informe

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae32e1f3883288a0b7cf5cc2f345e