### PR TITLE
Prevent background scroll when email modal is open

### DIFF
--- a/src/components/SendEmailModal.jsx
+++ b/src/components/SendEmailModal.jsx
@@ -168,6 +168,32 @@ export default function SendEmailModal({
     }
   }, [show])
 
+  useEffect(() => {
+    if (!show || typeof document === 'undefined') return undefined
+
+    const { body, documentElement } = document
+    const originalOverflow = body.style.overflow
+    const originalPaddingRight = body.style.paddingRight
+    const hadModalOpenClass = body.classList.contains('modal-open')
+
+    body.classList.add('modal-open')
+
+    const scrollbarWidth = window.innerWidth - documentElement.clientWidth
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`
+    }
+
+    body.style.overflow = 'hidden'
+
+    return () => {
+      if (!hadModalOpenClass) {
+        body.classList.remove('modal-open')
+      }
+      body.style.overflow = originalOverflow
+      body.style.paddingRight = originalPaddingRight
+    }
+  }, [show])
+
   const parsedTo = useMemo(() => collectEmails(to), [to])
   const parsedCc = useMemo(() => collectEmails(cc), [cc])
   const parsedBcc = useMemo(() => collectEmails(bcc), [bcc])


### PR DESCRIPTION
## Summary
- add an effect that applies Bootstrap's `modal-open` behaviour when the send-email modal is displayed
- restore the body overflow and padding styles when the modal closes to avoid scrolling the background while the popup is open

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf27dafa88328a81bfb42f3d89051