### PR TITLE
Actualiza destinatarios automáticos del envío de informes

### DIFF
--- a/netlify/functions/sendReportEmail.js
+++ b/netlify/functions/sendReportEmail.js
@@ -190,7 +190,7 @@ exports.handler = async (event) => {
 
     const pdfBase64 = resolvePdfBase64(body.pdf)
 
-    const from = process.env.REPORTS_EMAIL_FROM || process.env.RESEND_FROM || 'informes@gepservices.es'
+    const from = 'julio@gepgroup.es'
     const replyTo = body.replyTo || process.env.REPORTS_EMAIL_REPLY_TO || ''
 
     const textMessage = typeof body.message === 'string' ? body.message : ''


### PR DESCRIPTION
## Summary
- Actualiza los destinatarios por defecto del popup de envío para incluir a jaime@gepgroup.es en Para y asignar automáticamente el correo del comercial en CC.
- Fija el remitente del correo saliente a julio@gepgroup.es en la función de Netlify.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb1970665c83288a5a40f7a4a0a3a1