### PR TITLE
Update default fallback commercial email address

### DIFF
--- a/src/components/SendEmailModal.jsx
+++ b/src/components/SendEmailModal.jsx
@@ -117,7 +117,7 @@ const resolveComercialEmail = (comercial) => {
     case 'julio garcia':
       return 'julio@gepgroup.es'
     default:
-      return 'sale@gepgroup.es'
+      return 'sales@gepgroup.es'
   }
 }
 


### PR DESCRIPTION
## Summary
- update the fallback commercial email to use the sales@gepgroup.es alias

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1cf7ef9c83288517bc37f92feeed