### PR TITLE
Actualizar cuerpo predeterminado del correo con nuevo texto

### DIFF
--- a/src/components/SendEmailModal.jsx
+++ b/src/components/SendEmailModal.jsx
@@ -173,22 +173,36 @@ export default function SendEmailModal({
     return pieces.join(' · ') || 'Informe GEP'
   }, [title, cliente, formattedDate, dealId])
 
+  const formadorNombre = (draft?.datos?.formadorNombre || draft?.formador?.nombre || '').trim()
+  const tipoInforme = (draft?.type || draft?.datos?.tipo || '').toLowerCase()
+  const pdfFileName = pdf?.fileName || 'informe.pdf'
+
   const defaultMessage = useMemo(() => {
-    const greeting = contacto ? `Hola ${contacto},` : 'Hola,'
-    const mainLine = dealId
-      ? `Adjuntamos el informe correspondiente al presupuesto ${dealId}.`
-      : 'Adjuntamos el informe correspondiente.'
+    let responsableFallback = 'el formador'
+    if (tipoInforme === 'simulacro') responsableFallback = 'el auditor'
+    else if (tipoInforme === 'preventivo') responsableFallback = 'el bombero'
+
+    const responsable = formadorNombre || responsableFallback
+    const presupuesto = dealId || 'N/A'
+    const destinatario = contacto || 'N/A'
+    const empresa = cliente || 'N/A'
+
     const lines = [
-      greeting,
+      'Hola',
       '',
-      mainLine,
-      'Si necesitas cualquier aclaración o modificación, indícanoslo.',
+      `Informe realizado por ${responsable}`,
+      `Adjunto Informe referente al presupuesto ${presupuesto}`,
+      `Hazlo llegar a ${destinatario} de la empresa ${empresa}`,
       '',
-      'Un saludo,',
+      'Muchas gracias',
+      '',
       'GEP Group — Formación y Servicios',
+      '',
+      pdfFileName,
     ]
+
     return lines.join('\n')
-  }, [contacto, dealId])
+  }, [cliente, contacto, dealId, formadorNombre, pdfFileName, tipoInforme])
 
   useEffect(() => {
     if (show) {


### PR DESCRIPTION
## Summary
- actualicé el texto del cuerpo del email predeterminado para que siga el nuevo formato indicado con los datos del informe
- añadí valores de respaldo y el nombre del PDF adjunto al mensaje generado automáticamente

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe185df408328acb116a40ec8c64c