### PR TITLE
Remove PDF file name from default email body

### DIFF
--- a/src/components/SendEmailModal.jsx
+++ b/src/components/SendEmailModal.jsx
@@ -189,8 +189,6 @@ export default function SendEmailModal({
 
   const formadorNombre = (draft?.datos?.formadorNombre || draft?.formador?.nombre || '').trim()
   const tipoInforme = (draft?.type || draft?.datos?.tipo || '').toLowerCase()
-  const pdfFileName = pdf?.fileName || 'informe.pdf'
-
   const defaultMessage = useMemo(() => {
     let responsableFallback = 'el formador'
     if (tipoInforme === 'simulacro') responsableFallback = 'el auditor'
@@ -211,12 +209,10 @@ export default function SendEmailModal({
       'Muchas gracias',
       '',
       'GEP Group — Formación y Servicios',
-      '',
-      pdfFileName,
     ]
 
     return lines.join('\n')
-  }, [cliente, contacto, dealId, formadorNombre, pdfFileName, tipoInforme])
+  }, [cliente, contacto, dealId, formadorNombre, tipoInforme])
 
   useEffect(() => {
     if (show) {


### PR DESCRIPTION
## Summary
- stop inserting the attached PDF file name into the default email body generated in the send report modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf3f7af2083288e2838a7aa83ee13